### PR TITLE
Add scipy spmv wrapper

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
+*.ipynb
+.git
 .ipynb_checkpoints
 __pycache__
-*.swp
 .vscode

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,9 +9,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: setup python
-        run: sudo apt-get update && sudo apt-get install -y python3-{pip,numpy,scipy}
-      - name: pip install jax
-        run: pip install jax jaxlib pytest
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
+      - name: pip install packages
+        run: pip install numpy scipy jax jaxlib pytest
       - name: run tests
         run: pytest
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .ipynb_checkpoints
 __pycache__
+*.swp

--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ Please see various notebooks and unit tests for usage.
 ```
 git clone https://github.com/ins-amu/vbjax
 cd vbjax
-pip install .[test]
+pip install '.[test]'
 pytest
 ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
-## `vbjax`
+# `vbjax`
 
 `vbjax` is a Jax-based package for working with virtual brain style models.
+
+## Usage
 
 Installs with `pip install vbjax`, or manually install dependencies with
 `pip install numpy scipy jax jaxlib` or `conda install -y numpy scipy jax`.
 
 Please see various notebooks and unit tests for usage.
+
+## Development
+
+```
+git clone https://github.com/ins-amu/vbjax
+cd vbjax
+pip install .[test]
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,13 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
+[project.optional-dependencies]
+test = [
+  "pytest",
+  "pytest-xdist",
+  "pytest-benchmark"
+]
+
 [project.urls]
 "Homepage" = "https://github.com/ins-amu/vbjax"
 "Bug Tracker" = "https://github.com/ins-amu/vbjax/issues"

--- a/vbjax/__init__.py
+++ b/vbjax/__init__.py
@@ -4,4 +4,5 @@ from .neural_mass import JRState, JRTheta, jr_dfun, jr_default_theta
 from .regmap import make_region_mapping
 from .coupling import make_diff_cfun, make_linear_cfun
 from .connectome import make_conn_latent_mvnorm
+from .sparse import make_spmv
 from ._version import __version__

--- a/vbjax/sparse.py
+++ b/vbjax/sparse.py
@@ -1,0 +1,35 @@
+import numpy as np
+import jax.dlpack
+import scipy.sparse
+
+
+_to_np = lambda x: np.from_dlpack(x)
+_to_jax = lambda x: jax.dlpack.from_dlpack(x.__dlpack__())
+
+
+def make_spmv(A, is_symmetric=False):
+    """
+    Make a closure for a general sparse matrix-vector multiplication.
+
+    Parameters
+    ----------
+    A : scipy.sparse.csr_matrix
+        Constant sparse matrix.
+    is_symmetric : bool, optional, default False
+        Whether matrix is symmetric.
+
+    Returns
+    -------
+    spmv : function
+        Function implementing spase matrix vector multiply with
+        support for gradients in Jax.
+
+    """
+    AT = A.T.copy()
+    @jax.custom_vjp
+    def matvec(x):          return _to_jax(A @ _to_np(x))
+    def matvec_tr(x):       return _to_jax(AT @ _to_np(x))
+    def matvec_fwd(x):      return matvec(x), None
+    def matvec_bwd(res, g): return matvec(g) if is_symmetric else matvec_tr(g),
+    matvec.defvjp(matvec_fwd, matvec_bwd)
+    return matvec

--- a/vbjax/tests/test_jaxisms.py
+++ b/vbjax/tests/test_jaxisms.py
@@ -13,7 +13,7 @@ import jax.test_util
 def test_dlpack_numpy():
     x = numpy.random.randn(10)
     jx = jax.dlpack.from_dlpack(x.__dlpack__())
-    nx = numpy.from_dlpack(x)
+    nx = numpy.from_dlpack(jx)
     numpy.testing.assert_allclose(x, nx)
 
 def test_custom_vjp_simple():

--- a/vbjax/tests/test_jaxisms.py
+++ b/vbjax/tests/test_jaxisms.py
@@ -1,0 +1,31 @@
+"""
+These are tests of our understanding of how Jax works.  If these break
+then probably things elsewhere will also break.
+
+"""
+
+import jax
+import jax.test_util
+
+def test_custom_vjp_simple():
+
+    @jax.custom_vjp
+    def foo(a, b):
+        return 2*a+b, 3*a+0.5*b
+
+    def foo_fwd(a, b):
+        return foo(a, b), None
+
+    def foo_bwd(res, g):
+        g_1, g_2 = g
+        return (2*g[0]+3*g[1], g[0] + 0.5*g[1])
+
+    foo.defvjp(foo_fwd, foo_bwd)
+
+    def bar(a, b):
+        c, d = foo(a, b)
+        return 2*c + 3*d
+
+    jax.grad(bar, [0,1])(3.,4.)
+
+    jax.test_util.check_grads(bar, (3.0, 4.0), order=1, modes=('rev',))

--- a/vbjax/tests/test_jaxisms.py
+++ b/vbjax/tests/test_jaxisms.py
@@ -38,3 +38,8 @@ def test_custom_vjp_simple():
     jax.grad(bar, [0,1])(3.,4.)
 
     jax.test_util.check_grads(bar, (3.0, 4.0), order=1, modes=('rev',))
+
+
+if __name__ == '__main__':
+    test_dlpack_numpy()
+    test_custom_vjp_simple()

--- a/vbjax/tests/test_jaxisms.py
+++ b/vbjax/tests/test_jaxisms.py
@@ -4,8 +4,17 @@ then probably things elsewhere will also break.
 
 """
 
+import numpy
 import jax
+import jax.dlpack
 import jax.test_util
+
+
+def test_dlpack_numpy():
+    x = numpy.random.randn(10)
+    jx = jax.dlpack.from_dlpack(x.__dlpack__())
+    nx = numpy.from_dlpack(x)
+    numpy.testing.assert_allclose(x, nx)
 
 def test_custom_vjp_simple():
 

--- a/vbjax/tests/test_sparse.py
+++ b/vbjax/tests/test_sparse.py
@@ -1,0 +1,43 @@
+import numpy as np
+import jax
+import jax.test_util
+import jax.dlpack
+import jax.numpy as jnp
+import scipy.sparse
+
+
+def test_csr_scipy():
+    n = 10
+    A: scipy.sparse.csr_matrix = scipy.sparse.random(n, n, density=0.1).tocsr()
+    nx = np.random.randn(n)
+    jx = jnp.array(nx)
+
+    @jax.custom_vjp
+    def matvec(x):
+        nb = A @ np.from_dlpack(x)
+        db = jax.dlpack.from_dlpack(nb.__dlpack__())
+        return db
+
+    def matvec_tr(x):
+        nb = A.T @ np.from_dlpack(x)
+        db = jax.dlpack.from_dlpack(nb.__dlpack__())
+        return db
+
+    def matvec_fwd(x):
+        return matvec(x), None
+
+    def matvec_bwd(res, g):
+        return matvec_tr(g),
+
+    matvec.defvjp(matvec_fwd, matvec_bwd)
+
+    # test the function itself
+    jb = matvec(jx)
+    nb = A @ nx
+    np.testing.assert_allclose(jb, nb, 1e-6, 1e-6)
+
+    # now its gradient
+    jax.test_util.check_grads(matvec, (jx,), order=1, modes=('rev',))
+
+if __name__ == '__main__':
+    test_csr_scipy()


### PR DESCRIPTION
This adds starts #4 support for scipy spmv with constant sparse matrix,

- [x] test for passing Jax array via dlpack
- [x] public API spmv wrapper 
- [x] specialization for symmetric sparse matrix
- [x] benchmark comparing with Jax's BCOO format
