### PR TITLE
Add monitors

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,5 +5,3 @@ testpaths =
     vbjax/tests
 addopts = 
     -m 'not slow'
-log_cli=true
-log_level=INFO

--- a/vbjax/__init__.py
+++ b/vbjax/__init__.py
@@ -32,6 +32,7 @@ from .monitor import make_timeavg, make_bold, make_gain
 from .layers import make_dense_layers
 from .diagnostics import shrinkage_zscore
 from .embed import embed_neural_flow, embed_polynomial, embed_gradient, embed_autoregress
+from .util import to_jax, to_np
 from ._version import __version__
 
 # some random setup for convenience

--- a/vbjax/__init__.py
+++ b/vbjax/__init__.py
@@ -1,3 +1,4 @@
+print('vbjax ███▒▒▒▒▒▒▒ loading')
 
 # default to setting up many cores
 def _use_many_cores():
@@ -7,9 +8,9 @@ def _use_many_cores():
         n = mp.cpu_count()
         value = '--xla_force_host_platform_device_count=%d' % n
         os.environ['XLA_FLAGS'] = value
-        print(f'vbjax ( ˘ ³˘)ノ°ﾟº❍｡ using {n} cores')
+        print(f'vbjax (ﾉ☉ヮ⚆)ﾉ ⌒*:･ﾟ✧ can haz {n} cores')
     else:
-        sys.stderr.write('XLA_FLAGS already set\n')
+        print('vbjax XLA_FLAGS already set\n')
 
 _use_many_cores()
 
@@ -19,6 +20,7 @@ from .shtlc import make_shtdiff
 from .neural_mass import (
         JRState, JRTheta, jr_dfun, jr_default_theta,
         MPRState, MPRTheta, mpr_dfun, mpr_default_theta,
+        BOLDTheta, compute_bold_theta, bold_default_theta, bold_dfun
         )
 from .regmap import make_region_mapping
 from .coupling import (
@@ -26,6 +28,7 @@ from .coupling import (
         )
 from .connectome import make_conn_latent_mvnorm
 from .sparse import make_spmv, csr_to_jax_bcoo, make_sg_spmv
+from .monitor import make_timeavg, make_bold, make_gain
 from .layers import make_dense_layers
 from .diagnostics import shrinkage_zscore
 from .embed import embed_neural_flow, embed_polynomial, embed_gradient, embed_autoregress
@@ -79,3 +82,4 @@ def make_field_gif(xt, gifname, fps=15):
     writer = animation.PillowWriter(fps=fps, bitrate=400)
     ani.save(gifname, writer=writer)
 
+print('vbjax ᕕ(ᐛ)ᕗ ready')

--- a/vbjax/__init__.py
+++ b/vbjax/__init__.py
@@ -28,7 +28,7 @@ from .coupling import (
         )
 from .connectome import make_conn_latent_mvnorm
 from .sparse import make_spmv, csr_to_jax_bcoo, make_sg_spmv
-from .monitor import make_timeavg, make_bold, make_gain
+from .monitor import make_timeavg, make_bold, make_gain, make_offline
 from .layers import make_dense_layers
 from .diagnostics import shrinkage_zscore
 from .embed import embed_neural_flow, embed_polynomial, embed_gradient, embed_autoregress

--- a/vbjax/monitor.py
+++ b/vbjax/monitor.py
@@ -1,0 +1,56 @@
+import jax.numpy as np
+from .loops import heun_step
+from .neural_mass import BOLDTheta, bold_dfun
+
+
+def make_timeavg(shape):
+    "Make a time average monitor."
+    new = lambda : {'y': np.zeros(shape), 'n': 0}
+    def step(buf, x):
+        return {'y': buf['y'] + x,
+                'n': buf['n'] + 1}
+    def sample(buf):
+        return new(), buf['y'] / buf['n']
+    return new(), step, sample
+
+
+def compute_sarvas_gain(q, r, o, att, Ds=0, Dc=0) -> np.ndarray:
+    # https://gist.github.com/maedoc/add7c3206f81d59105753a04f7c1fcf4
+    pass
+
+
+def make_gain(gain, shape):
+    "Make a gain-matrix monitor suitable for sEEG, EEG & MEG."
+    tavg_shape = gain.shape[:1] + shape[1:]
+    buf, tavg_step, tavg_sample = make_timeavg(tavg_shape)
+    step = lambda b, x: tavg_step(b, gain @ x)
+    return buf, step, tavg_sample
+
+
+def make_bold(shape, dt, p: BOLDTheta):
+    "Make a BOLD fMRI monitor."
+    sfvq = np.ones((4,) + shape)
+    sfvq = sfvq.at[0].set(0)
+    def step(sfvq, x):
+        return heun_step(sfvq, bold_dfun, dt, x, p)
+    def sample(buf):
+        s, f, v, q = buf
+        return p.v0 * (p.k1*(1 - q) + p.k2*(1 - q / v) + p.k3*(1 - v))
+    return sfvq, step, sample
+
+
+def make_fc(shape, period):
+    # welford online cov estimate yields o(1) backprop memory usage
+    # https://github.com/maedoc/tvb-fut/blob/master/lib/github.com/maedoc/tvb-fut/stats.fut#L9
+    pass
+
+def make_fft(shape, period):
+    # incremental ft doesn't really exist, do windowed instead
+    pass
+
+# TODO sliding window versions of those
+
+# monitors don't have same periods:
+# core loop function takes one step
+# does that enough to produce the largest period?
+# @jax.checkpoint to lower memory usage?

--- a/vbjax/monitor.py
+++ b/vbjax/monitor.py
@@ -36,7 +36,7 @@ def make_bold(shape, dt, p: BOLDTheta):
         return heun_step(sfvq, bold_dfun, dt, x, p)
     def sample(buf):
         s, f, v, q = buf
-        return p.v0 * (p.k1*(1 - q) + p.k2*(1 - q / v) + p.k3*(1 - v))
+        return buf, p.v0 * (p.k1*(1 - q) + p.k2*(1 - q / v) + p.k3*(1 - v))
     return sfvq, step, sample
 
 

--- a/vbjax/monitor.py
+++ b/vbjax/monitor.py
@@ -2,6 +2,7 @@ import jax.numpy as np
 from .loops import heun_step
 from .neural_mass import BOLDTheta, bold_dfun
 
+# NB shape here is the input shape of neural activity
 
 def make_timeavg(shape):
     "Make a time average monitor."
@@ -19,9 +20,9 @@ def compute_sarvas_gain(q, r, o, att, Ds=0, Dc=0) -> np.ndarray:
     pass
 
 
-def make_gain(gain, shape):
+def make_gain(gain, shape=None):
     "Make a gain-matrix monitor suitable for sEEG, EEG & MEG."
-    tavg_shape = gain.shape[:1] + shape[1:]
+    tavg_shape = gain.shape[:1] + (shape[1:] if shape else ())
     buf, tavg_step, tavg_sample = make_timeavg(tavg_shape)
     step = lambda b, x: tavg_step(b, gain @ x)
     return buf, step, tavg_sample
@@ -45,12 +46,8 @@ def make_fc(shape, period):
     pass
 
 def make_fft(shape, period):
-    # incremental ft doesn't really exist, do windowed instead
     pass
 
 # TODO sliding window versions of those
 
-# monitors don't have same periods:
-# core loop function takes one step
-# does that enough to produce the largest period?
 # @jax.checkpoint to lower memory usage?

--- a/vbjax/neural_mass.py
+++ b/vbjax/neural_mass.py
@@ -79,3 +79,48 @@ def mpr_dfun(ys, c, p):
         (1 / p.tau) * (V ** 2 + p.eta + p.J * p.tau *
          r + p.I + I_c - (np.pi ** 2) * (r ** 2) * (p.tau ** 2))
     ])
+
+
+BOLDTheta = collections.namedtuple(
+    typename='BOLDTheta',
+    field_names='tau_s,tau_f,tau_o,alpha,te,v0,e0,epsilon,nu_0,'
+                'r_0,recip_tau_s,recip_tau_f,recip_tau_o,recip_alpha,'
+                'recip_e0,k1,k2,k3'
+)
+
+def compute_bold_theta(
+        tau_s=0.65,
+        tau_f=0.41,
+        tau_o=0.98,
+        alpha=0.32,
+        te=0.04,
+        v0=4.0,
+        e0=0.4,
+        epsilon=0.5,
+        nu_0=40.3,
+        r_0=25.0,
+    ):
+    recip_tau_s = 1.0 / tau_s
+    recip_tau_f = 1.0 / tau_f
+    recip_tau_o = 1.0 / tau_o
+    recip_alpha = 1.0 / alpha
+    recip_e0 = 1.0 / e0
+    k1 = 4.3 * nu_0 * e0 * te
+    k2 = epsilon * r_0 * e0 * te
+    k3 = 1.0 - epsilon
+    return BOLDTheta(**locals())
+
+bold_default_theta = compute_bold_theta()
+
+def bold_dfun(sfvq, x, p: BOLDTheta):
+    s, f, v, q = sfvq
+    ds = x - p.recip_tau_s * s - p.recip_tau_f * (f - 1)
+    df = s
+    dv = p.recip_tau_o * (f - v ** p.recip_alpha)
+    dq = p.recip_tau_o * (f * (1 - (1 - p.e0) ** (1 / f)) * p.recip_e0
+                          - v ** p.recip_alpha * (q / v))
+    return np.array([ds, df, dv, dq])
+
+
+# TODO other models
+# TODO codim3 https://gist.github.com/maedoc/01cea5cad9c833c56349392ee7d9b627

--- a/vbjax/shtlc.py
+++ b/vbjax/shtlc.py
@@ -5,8 +5,7 @@ import scipy.special as sp
 try:
     import shtns
 except ImportError:
-    import sys
-    sys.stderr.write('** shtns is not available\n')
+    print('vbjax ò_ô shtns is not available')
 
 
 # Grid functions

--- a/vbjax/sparse.py
+++ b/vbjax/sparse.py
@@ -1,11 +1,8 @@
 import numpy as np
-import jax.dlpack
 import scipy.sparse
+import jax
 import jax.experimental.sparse as jsp
-
-
-_to_np = lambda x: np.from_dlpack(x)
-_to_jax = lambda x: jax.dlpack.from_dlpack(x.__dlpack__())
+import vbjax as vb
 
 
 def make_spmv(A, is_symmetric=False, use_scipy=False):
@@ -30,8 +27,8 @@ def make_spmv(A, is_symmetric=False, use_scipy=False):
     """
     AT = A.T.copy()
     @jax.custom_vjp
-    def matvec(x):          return _to_jax(A @ _to_np(x))
-    def matvec_tr(x):       return _to_jax(AT @ _to_np(x))
+    def matvec(x):          return vb.to_jax(A @ vb.to_np(x))
+    def matvec_tr(x):       return vb.to_jax(AT @ vb.to_np(x))
     def matvec_fwd(x):      return matvec(x), None
     def matvec_bwd(res, g): return matvec(g) if is_symmetric else matvec_tr(g),
     matvec.defvjp(matvec_fwd, matvec_bwd)

--- a/vbjax/tests/test_loops.py
+++ b/vbjax/tests/test_loops.py
@@ -40,3 +40,6 @@ def test_sdde():
         return -xt[t - 5]
     _, sdde = vb.make_sdde(1.0, 5, dfun, 0.01)
     sdde(vb.randn(20)+10, None)
+
+
+# TODO theta method? https://gist.github.com/maedoc/c47acb9d346e31017e05324ffc4582c1

--- a/vbjax/tests/test_monitor.py
+++ b/vbjax/tests/test_monitor.py
@@ -17,6 +17,18 @@ def test_timeavg():
     numpy.testing.assert_allclose(ta, 2.0)
 
 
+def test_offline():
+    buf, ta_step, ta_sample = vb.make_timeavg((1,))
+    bufo, _, _ = vb.make_timeavg((1,))
+    ta_off = vb.make_offline(ta_step, ta_sample)
+    xs = vb.randn(20, 100)
+    for j, x_j in enumerate(xs):
+        for i, x_ji in enumerate(x_j):
+            buf = ta_step(buf, x_ji)
+        buf, ta = ta_sample(buf)
+        bufo, tao = ta_off(bufo, x_j)
+        numpy.testing.assert_allclose(tao, ta)
+
 def test_gain():
     gain = vb.randn(4, 4)
     ones = np.ones((4, ))
@@ -50,6 +62,8 @@ def setup_multiple_periods(unroll, checkpoint):
     # setup monitors
     eeg_gain = vb.randn(64, 32)
     eeg_buf, eeg_step, eeg_sample = vb.make_gain(eeg_gain)
+    eeg2_buf, eeg2_step, eeg2_sample = vb.make_gain(eeg_gain)
+    eeg2_offline_sample = vb.make_offline(eeg2_step, eeg2_sample)
     bold_buf, bold_step, bold_sample = vb.make_bold((eeg_gain.shape[1], ),
                                                 0.1, vb.bold_default_theta)
 
@@ -57,6 +71,7 @@ def setup_multiple_periods(unroll, checkpoint):
     # TODO may be easier with jax_dataclasses
     sim = {
         'eeg_buf': eeg_buf,
+        'eeg2_buf': eeg2_buf,
         'bold_buf': bold_buf,
         'freq': 0.1,
     }
@@ -78,26 +93,31 @@ def setup_multiple_periods(unroll, checkpoint):
         sim, raw = jax.lax.scan(op1, sim, t_ * 10 + np.r_[:10],
                                 unroll=10)
         sim['eeg_buf'], eeg_t = eeg_sample(sim['eeg_buf'])
-        return sim, (raw, eeg_t)
+        sim['eeg2_buf'], eeg2_t = eeg2_offline_sample(sim['eeg2_buf'],
+                                                      np.sin(raw * sim['freq']))
+        return sim, (raw, eeg_t, eeg2_t)
 
     # outer scan steps from one bold sample to the next
     def op3(sim, T):
         # run for 5 samples of eeg
-        sim, (raw, eeg) = jax.lax.scan(op2, sim, T*50 + np.r_[:5],
+        sim, (raw, eeg, eeg2) = jax.lax.scan(op2, sim, T*50 + np.r_[:5],
                                        unroll=5 if unroll else 1)
         # sample fmri w/ period of 5*10*dt
         _, fmri = bold_sample(sim['bold_buf'])
-        return sim, (raw, eeg, fmri)
+        return sim, (raw, eeg, eeg2, fmri)
 
     return sim, op3
 
 def test_multiple_periods():
     sim, op3 = setup_multiple_periods(False, False,)
     ts = np.r_[:10]
-    sim, (raw, eeg, fmri) = jax.lax.scan(op3, sim, ts)
+    sim, (raw, eeg, eeg2, fmri) = jax.lax.scan(op3, sim, ts)
     assert raw.shape == (ts.size, 5, 10, 32)
     assert eeg.shape == (ts.size, 5, 64)
+    assert eeg2.shape == (ts.size, 5, 64)
     assert fmri.shape == (ts.size, 32)
+    numpy.testing.assert_allclose(eeg2, eeg, 2e-3, 1e-4)
+
 
 @pytest.mark.parametrize('opts', [
     f'{args} {dev}'

--- a/vbjax/tests/test_monitor.py
+++ b/vbjax/tests/test_monitor.py
@@ -1,0 +1,45 @@
+import numpy
+import jax.numpy as np
+import vbjax as vb
+
+
+def test_timeavg():
+    buf, ta_step, ta_sample = vb.make_timeavg((4,))
+
+    buf = ta_step(buf, 1.0)
+    buf = ta_step(buf, np.r_[:4])
+    buf, ta = ta_sample(buf)
+    numpy.testing.assert_allclose(ta, (1+np.r_[:4])/2)
+
+    buf = ta_step(buf, 2.0)
+    buf, ta = ta_sample(buf)
+    numpy.testing.assert_allclose(ta, 2.0)
+
+
+def test_gain():
+    gain = vb.randn(4, 4)
+    ones = np.ones((4, ))
+    buf, g_step, g_sample = vb.make_gain(gain, ones.shape)
+
+    buf = g_step(buf, ones)
+    buf = g_step(buf, ones)
+    buf = g_step(buf, ones)
+
+    buf, eeg = g_sample(buf)
+
+    numpy.testing.assert_allclose(eeg, gain.sum(axis=1))
+
+
+def test_bold():
+    n = 8
+    dt = 0.1
+    p = vb.bold_default_theta
+    buf, b_step, b_sample = vb.make_bold((n, ), dt, p)
+
+    buf = b_step(buf, vb.randn(n))
+    buf = b_step(buf, vb.randn(n))
+    buf = b_step(buf, vb.randn(n))
+
+    fmri = b_sample(buf)
+    assert fmri.shape == (n,)
+

--- a/vbjax/tests/test_sparse.py
+++ b/vbjax/tests/test_sparse.py
@@ -90,7 +90,7 @@ def test_perf_jbcoo(benchmark, n, density_pct, grad, impl, jit):
     if impl == 'scipy': # TODO enum
         spmv1 = vbjax.make_spmv(A)
     elif impl == 'jaxbcoo':
-        jA = _csr_to_jax_bcoo(A)
+        jA = vbjax.csr_to_jax_bcoo(A)
         spmv1 = lambda x: jA @ x
     else:
         raise ValueError(impl)

--- a/vbjax/util.py
+++ b/vbjax/util.py
@@ -1,0 +1,17 @@
+import numpy
+import jax
+import jax.dlpack
+
+
+def to_np(x: jax.numpy.ndarray) -> numpy.ndarray:
+    if jax.default_backend() == 'gpu':
+        return numpy.array(x)
+    return numpy.from_dlpack(x)
+
+def to_jax(x: numpy.ndarray):
+    "Move NumPy array to JAX via DLPack."
+    x_dlp = x.__dlpack__()
+    x_jax: jax.numpy.ndarray = jax.dlpack.from_dlpack(x_dlp)
+    # if jax.default_backend() == 'gpu':
+    #     x_jax = jax.device_put(x_jax)
+    return x_jax


### PR DESCRIPTION
This PR addes preliminary support for monitors 

- temporal average
- gain-matrix based monitors like EEG, MEG
- fMRI/BOLD with the Balloon-Windkessel model

Monitors run "online" during simulation or offline with a `make_offline` adapter`. 