### PR TITLE
add flax-based MAF

### DIFF
--- a/vbjax/__init__.py
+++ b/vbjax/__init__.py
@@ -20,8 +20,8 @@ def _use_many_cores():
 cores = _use_many_cores()
 
 # import stuff
-from .loops import make_sde, make_ode, make_dde, make_sdde, heun_step, make_continuation
-from .noise_generator import noise_psd
+from .custom_loops import make_sde, make_ode, make_dde, make_sdde, heun_step, make_continuation
+from .noise_generator import make_noise_generator, spectral_exponent
 from .shtlc import make_shtdiff
 from .neural_mass import (
     JRState, JRTheta, jr_dfun, jr_default_theta,
@@ -37,10 +37,12 @@ from .connectome import make_conn_latent_mvnorm
 from .sparse import make_spmv, csr_to_jax_bcoo, make_sg_spmv
 from .monitor import (
     make_timeavg, make_bold, make_gain, make_offline, make_cov, make_fc)
-from .layers import make_dense_layers
+from .layers import make_dense_layers, create_degrees, create_masks, MaskedLayer, MaskedMLP, OutputLayer
+from .ml_models import GaussianMADE
 from .diagnostics import shrinkage_zscore
 from .embed import embed_neural_flow, embed_polynomial, embed_gradient, embed_autoregress
 from .util import to_jax, to_np
+from .train_utils import eval_MADE, train_step, log_likelihood, grad_func
 from ._version import __version__
 
 # some random setup for convenience

--- a/vbjax/__init__.py
+++ b/vbjax/__init__.py
@@ -20,7 +20,7 @@ def _use_many_cores():
 cores = _use_many_cores()
 
 # import stuff
-from .loops import make_sde, make_ode, make_dde, make_sdde, heun_step, make_continuation
+from .custom_loops import make_sde, make_ode, make_dde, make_sdde, heun_step, make_continuation
 from .noise_generator import make_noise_generator, spectral_exponent
 from .shtlc import make_shtdiff
 from .neural_mass import (
@@ -39,12 +39,14 @@ from .connectome import make_conn_latent_mvnorm
 from .sparse import make_spmv, csr_to_jax_bcoo, make_sg_spmv
 from .monitor import (
     make_timeavg, make_bold, make_gain, make_offline, make_cov, make_fc)
-from .layers import make_dense_layers, create_degrees, create_masks, MaskedLayer, MaskedMLP, OutputLayer
+from .layers import (make_dense_layers, create_degrees, create_masks, 
+    MaskedLayer, MaskedMLP, OutputLayer)
 from .ml_models import GaussianMADE, MAF
 from .diagnostics import shrinkage_zscore
 from .embed import embed_neural_flow, embed_polynomial, embed_gradient, embed_autoregress
 from .util import to_jax, to_np, tuple_meshgrid, tuple_ravel, tuple_shard
-from .train_utils import eval_model, train_step, log_likelihood_MADE, log_likelihood_MAF, grad_func
+from .train_utils import (eval_model, train_step, log_likelihood_MADE, 
+    log_likelihood_MAF, grad_func)
 
 from ._version import __version__
 

--- a/vbjax/__init__.py
+++ b/vbjax/__init__.py
@@ -21,6 +21,7 @@ cores = _use_many_cores()
 
 # import stuff
 from .loops import make_sde, make_ode, make_dde, make_sdde, heun_step, make_continuation
+from .noise_generator import noise_psd
 from .shtlc import make_shtdiff
 from .neural_mass import (
     JRState, JRTheta, jr_dfun, jr_default_theta,

--- a/vbjax/__init__.py
+++ b/vbjax/__init__.py
@@ -40,11 +40,11 @@ from .sparse import make_spmv, csr_to_jax_bcoo, make_sg_spmv
 from .monitor import (
     make_timeavg, make_bold, make_gain, make_offline, make_cov, make_fc)
 from .layers import make_dense_layers, create_degrees, create_masks, MaskedLayer, MaskedMLP, OutputLayer
-from .ml_models import GaussianMADE
+from .ml_models import GaussianMADE, MAF
 from .diagnostics import shrinkage_zscore
 from .embed import embed_neural_flow, embed_polynomial, embed_gradient, embed_autoregress
 from .util import to_jax, to_np, tuple_meshgrid, tuple_ravel, tuple_shard
-from .train_utils import eval_MADE, train_step, log_likelihood, grad_func
+from .train_utils import eval_model, train_step, log_likelihood_MADE, log_likelihood_MAF, grad_func
 
 from ._version import __version__
 

--- a/vbjax/__init__.py
+++ b/vbjax/__init__.py
@@ -20,7 +20,7 @@ def _use_many_cores():
 cores = _use_many_cores()
 
 # import stuff
-from .custom_loops import make_sde, make_ode, make_dde, make_sdde, heun_step, make_continuation
+from .loops import make_sde, make_ode, make_dde, make_sdde, heun_step, make_continuation
 from .noise_generator import make_noise_generator, spectral_exponent
 from .shtlc import make_shtdiff
 from .neural_mass import (

--- a/vbjax/layers.py
+++ b/vbjax/layers.py
@@ -157,4 +157,17 @@ class MaskedMLP(nn.Module):
         return x
 
 
+class FourierLayer(nn.Module):
+  kernel_init: Callable = lambda key, shape: jax.random.normal(key, shape=shape)/jnp.sqrt(shape[0])
+  bias_init: Callable = nn.initializers.zeros_init()
 
+  @nn.compact
+  def __call__(self, inputs):
+    kernel = self.param('kernel',
+                        self.kernel_init, # Initialization function
+                        (inputs.shape[-1], 1))  # shape info.
+
+    bias_m = self.param('bias', self.bias_init, (1,))
+    m = jnp.dot(inputs, kernel)
+    m = m + bias_m
+    return m

--- a/vbjax/layers.py
+++ b/vbjax/layers.py
@@ -1,4 +1,9 @@
 import jax
+import jax.numpy as jnp
+from flax import linen as nn
+from typing import Callable, Sequence
+from jaxlib.xla_extension import ArrayImpl
+import jax.random as random
 
 
 def make_dense_layers(in_dim, latent_dims=[10], out_dim=None, init_scl=0.1, extra_in=0,
@@ -24,3 +29,133 @@ def make_dense_layers(in_dim, latent_dims=[10], out_dim=None, init_scl=0.1, extr
         return weights[-1] @ x + biases[-1]
     
     return (weights, biases), fwd
+
+
+def create_degrees(key, n_inputs, n_hiddens, input_order, mode):
+    """
+    Generates a degree for each hidden and input unit. A unit with degree d can only receive input from units with
+    degree less than d.
+    :param n_inputs: the number of inputs
+    :param n_hiddens: a list with the number of hidden units
+    :param input_order: the order of the inputs; can be 'random', 'sequential', or an array of an explicit order
+    :param mode: the strategy for assigning degrees to hidden nodes: can be 'random' or 'sequential'
+    :return: list of degrees
+    """
+
+    degrees = []
+
+    # create degrees for inputs
+    if isinstance(input_order, str):
+
+        if input_order == 'random':
+            degrees_0 = jnp.arange(1, n_inputs + 1)
+            jax.random.permutation(key, degrees_0)
+
+        elif input_order == 'sequential':
+            degrees_0 = jnp.arange(1, n_inputs + 1)
+
+        else:
+            raise ValueError('invalid input order')
+
+    else:
+        input_order = jnp.array(input_order)
+        assert jnp.all(jnp.sort(input_order) == jnp.arange(1, n_inputs + 1)), 'invalid input order'
+        degrees_0 = input_order
+    degrees.append(degrees_0)
+
+    # create degrees for hiddens
+    if mode == 'random':
+        for N in n_hiddens:
+            min_prev_degree = min(jnp.min(degrees[-1]), n_inputs - 1)
+            degrees_l = jax.random.randint(key, shape=(N,), minval=min_prev_degree, maxval=n_inputs)
+            degrees.append(degrees_l)
+
+    elif mode == 'sequential':
+        for N in n_hiddens:
+            degrees_l = jnp.arange(N) % max(1, n_inputs - 1) + min(1, n_inputs - 1)
+            degrees.append(degrees_l)
+
+    else:
+        raise ValueError('invalid mode')
+
+    return degrees
+
+
+def create_masks(degrees):
+    """
+    Creates the binary masks that make the connectivity autoregressive.
+    :param degrees: a list of degrees for every layer
+    :return: list of all masks, as theano shared variables
+    """
+
+    Ms = []
+
+    for l, (d0, d1) in enumerate(zip(degrees[:-1], degrees[1:])):
+        M = d0[:, jnp.newaxis] <= d1
+        # M = theano.shared(M.astype(dtype), name='M' + str(l+1), borrow=True)
+        Ms.append(M)
+
+    Mmp = degrees[-1][:, jnp.newaxis] < degrees[0]
+    # Mmp = theano.shared(Mmp.astype(dtype), name='Mmp', borrow=True)
+
+    return Ms, Mmp
+
+
+class MaskedLayer(nn.Module):
+  features: int
+  mask: ArrayImpl
+  kernel_init: Callable = lambda key, shape, mask: random.normal(key, shape=shape)*mask
+  bias_init: Callable = nn.initializers.zeros_init()
+
+  @nn.compact
+  def __call__(self, inputs):
+    kernel = self.param('kernel',
+                        self.kernel_init, # Initialization function
+                        (inputs.shape[-1], self.features), self.mask)  # shape info.
+    y = jnp.dot(inputs, kernel*self.mask)
+    bias = self.param('bias', self.bias_init, (self.features,))
+    y = y + bias
+    return y
+
+
+class OutputLayer(nn.Module):
+  out_dim: int
+  out_mask: ArrayImpl
+  kernel_init: Callable = lambda key, shape, out_mask: jax.random.normal(key, shape=shape)/jnp.sqrt(shape[0])*out_mask
+  bias_init: Callable = nn.initializers.zeros_init()
+
+  @nn.compact
+  def __call__(self, inputs):
+    kernel_m = self.param('kernel_m',
+                        self.kernel_init, # Initialization function
+                        (inputs.shape[-1], self.out_dim), self.out_mask)  # shape info.
+    kernel_logp = self.param('kernel_logp',
+                        self.kernel_init, # Initialization function
+                        (inputs.shape[-1], self.out_dim), self.out_mask)
+    m = jnp.dot(inputs, kernel_m*self.out_mask)
+    logp = jnp.dot(inputs, kernel_logp*self.out_mask)
+    bias_m = self.param('bias_m', self.bias_init, (self.out_dim,))
+    bias_logp = self.param('bias_logp', self.bias_init, (self.out_dim,))
+    m = m + bias_m
+    logp = logp + bias_logp
+    return m, logp
+
+
+class MaskedMLP(nn.Module):
+    n_hiddens: Sequence[int]
+    act_fn: Callable
+    masks: Sequence[ArrayImpl]
+
+    def setup(self):
+        self.hidden = [MaskedLayer(mask.shape[1], mask) for mask in self.masks]
+    
+    def __call__(self, inputs):
+        x = inputs
+        for i, (layer,) in enumerate(zip(self.hidden)):
+            x = layer(x)
+            # if i != len(self.hidden) - 1:
+            x = self.act_fn(x)
+        return x
+
+
+

--- a/vbjax/layers.py
+++ b/vbjax/layers.py
@@ -30,7 +30,6 @@ def make_dense_layers(in_dim, latent_dims=[10], out_dim=None, init_scl=0.1, extr
     
     return (weights, biases), fwd
 
-
 def create_degrees(key, n_inputs, n_hiddens, input_order, mode):
     """
     Generates a degree for each hidden and input unit. A unit with degree d can only receive input from units with

--- a/vbjax/layers.py
+++ b/vbjax/layers.py
@@ -103,7 +103,7 @@ def create_masks(degrees):
 class MaskedLayer(nn.Module):
   features: int
   mask: ArrayImpl
-  kernel_init: Callable = lambda key, shape, mask: random.normal(key, shape=shape)*mask
+  kernel_init: Callable = lambda key, shape, mask: random.normal(key, shape=shape)*1e-3*mask
   bias_init: Callable = nn.initializers.zeros_init()
 
   @nn.compact

--- a/vbjax/loops.py
+++ b/vbjax/loops.py
@@ -128,7 +128,7 @@ def make_sde(dt, dfun, gfun, adhoc=None, return_euler=False, unroll=10):
     return step, loop
 
 
-def make_ode(dt, dfun, adhoc=None, stim=False):
+def make_ode(dt, dfun, adhoc=None):
     """Use a Heun scheme to integrate autonomous ordinary differential
     equations (ODEs).
 
@@ -166,10 +166,7 @@ def make_ode(dt, dfun, adhoc=None, stim=False):
     """
 
     def step(x, t, p):
-        if stim:
-            return heun_step(x, dfun, dt, p, t, adhoc=adhoc)
-        else:
-            return heun_step(x, dfun, dt, p, adhoc=adhoc)
+        return heun_step(x, dfun, dt, p, adhoc=adhoc)
 
     @jax.jit
     def loop(x0, ts, p):
@@ -307,7 +304,6 @@ def make_continuation(run_chunk, chunk_len, max_lag, n_from, n_svar, stochastic=
 
     @jax.jit
     def continue_chunk(buf, p, key):
-        buf, rv = run_chunk(buf, p)
         get, set = jax.lax.dynamic_slice, jax.lax.dynamic_update_slice
         # buf = buf.at[:max_lag+1].set( buf[-(max_lag+1):] )
         buf = set(buf, get(buf, (i0,0,0), (i1,n_svar,n_from)), (0,0,0))
@@ -321,6 +317,6 @@ def make_continuation(run_chunk, chunk_len, max_lag, n_from, n_svar, stochastic=
             # leave the buf since gfun() returns zero
             pass
 
-        
+        buf, rv = run_chunk(buf, p)
         return buf, rv
     return continue_chunk

--- a/vbjax/ml_models.py
+++ b/vbjax/ml_models.py
@@ -1,6 +1,6 @@
 import jax.numpy as jnp
 from flax import linen as nn
-from typing import Callable, Sequence
+from typing import Callable, Sequence, Optional
 from jax._src.prng import PRNGKeyArrayImpl
 import jax.random as random
 from vbjax.layers import MaskedMLP, OutputLayer, create_degrees, create_masks
@@ -11,27 +11,23 @@ class GaussianMADE(nn.Module):
     in_dim: int
     n_hiddens: Sequence[int]
     act_fn: Callable
+    input_order: str = 'sequential'
+    mode: str = 'sequential'
 
     def setup(self):
-        self.degrees = create_degrees(self.key, self.in_dim, self.n_hiddens, input_order='sequential', mode='sequential')
+        self.degrees = create_degrees(self.key, self.in_dim, self.n_hiddens, input_order=self.input_order, mode=self.mode)
         self.masks, self.out_mask = create_masks(self.degrees)
         self.mlp = MaskedMLP(self.n_hiddens, self.act_fn, self.masks)
         self.output_layer = OutputLayer(self.in_dim, self.out_mask)
 
     
     def __call__(self, inputs):
-        h = self.mlp(inputs) 
-        m, logp = self.output_layer(h) 
+        h = self.mlp(inputs)
+        m, logp = self.output_layer(h)
         return m, logp
 
 
     def gen(self, key, shape, u=None):
-        """
-        Generate samples from made. Requires as many evaluations as number of inputs.
-        :param n_samples: number of samples
-        :param u: random numbers to use in generating samples; if None, new random numbers are drawn
-        :return: samples
-        """
         x = jnp.zeros(shape)
         u = random.normal(key, shape) if u is None else u
 
@@ -40,4 +36,35 @@ class GaussianMADE(nn.Module):
             m, logp = self.output_layer(h) 
             idx = jnp.argwhere(self.degrees[0] == i)[0, 0]
             x = x.at[:, idx].set(m[:, idx] + jnp.exp(jnp.minimum(-0.5 * logp[:, idx], 10.0)) * u[:, idx])
+        return x
+
+
+class MAF(nn.Module):
+    key: PRNGKeyArrayImpl
+    in_dim: int
+    n_hiddens: Sequence[int]
+    act_fn: Callable
+    n_mades: int
+    input_order: Optional[Sequence] = None
+    mode: str = 'sequential'
+
+    def setup(self, input_order: Optional[Sequence] = None):
+        input_order = jnp.arange(1, self.in_dim+1) if input_order == None else input_order
+        self.mades = [GaussianMADE(random.split(self.key), self.in_dim, self.n_hiddens, self.act_fn, input_order=input_order[::((-1)**(i%2))], mode=self.mode) for i in range(self.n_mades)]
+
+    def __call__(self, inputs):
+        u = inputs
+        logdet_dudx = 0
+        for made in self.mades:
+            ms, logp = made(u)
+            u = jnp.exp(0.5 * logp) * (u - ms)
+            logdet_dudx += 0.5 * jnp.sum(logp, axis=1)
+        return u, logdet_dudx
+
+    def gen(self, key, shape, u=None):
+        x = random.normal(key, shape) if u is None else u
+
+        for made in self.mades[::-1]:
+            x = made.gen(key, shape, x)
+
         return x

--- a/vbjax/ml_models.py
+++ b/vbjax/ml_models.py
@@ -4,7 +4,6 @@ from typing import Callable, Sequence, Optional
 from jax._src.prng import PRNGKeyArrayImpl
 import jax.random as random
 from vbjax.layers import MaskedMLP, OutputLayer, create_degrees, create_masks
-from vbjax.loops import make_ode_flax, heun_step
 import jax
 from flax.linen.initializers import zeros
 

--- a/vbjax/ml_models.py
+++ b/vbjax/ml_models.py
@@ -1,6 +1,6 @@
 import jax.numpy as jnp
 from flax import linen as nn
-from typing import Callable, Sequence, Optional
+from typing import Callable, Sequence, Optional, Any
 from collections import namedtuple, defaultdict
 from jax._src.prng import PRNGKeyArrayImpl
 import jax.random as random
@@ -8,7 +8,8 @@ from vbjax.layers import MaskedMLP, OutputLayer, create_degrees, create_masks
 import jax
 from flax.linen.initializers import zeros
 import tqdm
-from .neural_mass import BOLDTheta, bold_dfun
+from .neural_mass import bold_dfun, bold_default_theta, mpr_default_theta
+from flax.core.frozen_dict import freeze, unfreeze
 
 DelayHelper = namedtuple('DelayHelper', 'Wt lags ix_lag_from max_lag n_to n_from')
 
@@ -77,49 +78,55 @@ class MAF(nn.Module):
 
 class Heun_step(nn.Module):
     dfun: Callable
-    dt: float = 1.0
+    adhoc: Callable
+    dt: float
+    nh: Optional[int]
+    p: Optional[Any]
     stvar: Optional[int] = 0
     external_i: Optional[int] = False
-    adhoc: Optional[Callable] = None
+    
 
     @nn.compact
-    def __call__(self, x, xs, p, i_ext):
+    def __call__(self, x, xs, t, *args):
         tmap = jax.tree_util.tree_map
-        d1 = self.dfun((x, p), i_ext)
+        d1 = self.dfun(x, xs, *args) if self.p else self.dfun(x)
         xi = tmap(lambda x,d: x + self.dt*d, x, d1)
-        # xi = tmap(lambda x,d,a: x + dt*d + a, x, d1, stimulus)
+        xi = tmap(self.adhoc, xi)
 
-        d2 = self.dfun((xi, p), i_ext)
+        d2 = self.dfun(xi, xs, *args) if self.p else self.dfun(xi)
         nx = tmap(lambda x, d1,d2: x + self.dt*0.5*(d1 + d2), x, d1, d2)
-        # nx = tmap(lambda x, d1,d2,a: x + dt*0.5*(d1 + d2) + a, x, d1, d2, stimulus)
+        nx = tmap(self.adhoc, nx)
         return nx, x
 
 
 class Buffer_step(nn.Module):
     dfun: Callable
     adhoc: Callable
-    nh: int
-    dt: float = 1.0
-    t_step: int = 0
-    stvar: Optional[int] = 0
+    dt: float
+    nh: Optional[int]
+    p: Optional[Any]
     external_i: Optional[int] = False
+    
     
 
     @nn.compact
-    def __call__(self, buf, dWt, t, p=None, i_ext=0):
+    def __call__(self, buf, dWt, t, *args):
         t = t[0][0].astype(int) # retrieve time step
         nh = self.nh
-        
+        # jax.debug.print("time step t {x}", x=t)
         tmap = jax.tree_util.tree_map
         x = tmap(lambda buf: buf[nh + t], buf)
+        # jax.debug.print('STEP buf shape {x}', x=buf.shape)
+        # jax.debug.print('STEP x shape {x}', x=x.shape)
         d1 = self.dfun(buf, x, nh + t)
-
-        xi = tmap(lambda x,d,n: x + self.dt*d + n, x, d1, dWt)
-        # xi = self.adhoc(xi)
+        xi = tmap(lambda x,d,n: x + self.dt * d + n, x, d1, dWt)
         xi = tmap(self.adhoc, xi)
+        # jax.debug.print("time step x {x}", x=x)
+        # jax.debug.print("time step d1 {x}", x=d1)
 
         d2 = self.dfun(buf, xi, nh + t + 1)
-        nx = tmap(lambda x,d1,d2,n: x + self.dt*0.5*(d1 + d2) + n, x, d1, d2, dWt)
+        # jax.debug.print("time step d2 {x}", x=d2)
+        nx = tmap(lambda x,d1,d2,n: x + self.dt * 0.5*(d1 + d2) + n, x, d1, d2, dWt)
         nx = tmap(self.adhoc, nx)
         buf = tmap(lambda buf, nx: buf.at[nh + t + 1].set(nx), buf, nx)
         return buf, nx
@@ -132,16 +139,37 @@ class Integrator(nn.Module):
     dt: float = 1.0
     stvar: Optional[int] = 0
     nh: Optional[int] = None
+    p: Optional[Any] = True
+    in_ax: Optional[tuple] = (0,0)
 
     @nn.compact
-    def __call__(self, c, xs, t_count, p=None, external_i=None, t=0):
+    def __call__(self, c, xs, t_count, *args):
         STEP = nn.scan(self.step,
-                        variable_broadcast=["params", "noise"],
-                        split_rngs={"params": False, "noise": True},
-                        in_axes=(0, 0, 0, 0),
+                        # variable_broadcast=["params", "noise"],
+                        # split_rngs={"params": False, "noise": True},
+                        variable_broadcast=["params"],
+                        split_rngs={"params": False},                        
+                        in_axes=self.in_ax,
                         out_axes=0
                         )
-        return STEP(self.dfun, self.adhoc, self.nh, self.dt, self.stvar)(c, xs, t_count, p, external_i)
+        return STEP(self.dfun, self.adhoc, self.dt, self.nh, self.p)(c, xs, t_count, *args)
+
+
+class MontBrio(nn.Module):
+    
+    @nn.compact
+    def __call__(self, x, xs, c, p=mpr_default_theta):
+        # jax.debug.print("x shape {x}", x=x.shape)
+        
+        r, V = x[:,:1], x[:,1:]
+        I_c = c
+        # jax.debug.print("r ____ {x}", x=r[0])
+        # jax.debug.print("V ____ {x}", x=V[0])
+        r_dot =  (1 / p.tau) * (p.Delta / (jnp.pi * p.tau) + 2 * r * V)
+        v_dot = (1 / p.tau) * (V ** 2 + p.eta + p.J * p.tau * r + p.I + I_c - (jnp.pi ** 2) * (r ** 2) * (p.tau ** 2))
+        # jax.debug.print("r dot {x}", x=r_dot[0])
+        # jax.debug.print("V dot {x}", x=v_dot[0])
+        return jnp.c_[r_dot, v_dot]
 
 
 class TVB(nn.Module):
@@ -151,28 +179,26 @@ class TVB(nn.Module):
     nst_vars: int
     n_pars: int
     dfun_pars: defaultdict
+    # g_coupling: float
     dt: float = 0.1
-    seed: int = 42
     integrator: Optional[Callable] = Integrator
     step: Callable = Buffer_step
     adhoc: Callable = lambda x : x
     gfun: Callable = lambda x : x
+    ode: bool = False
 
     def delay_apply(self, dh: DelayHelper, t, buf):
         return (dh.Wt * buf[t - dh.lags, dh.ix_lag_from, :]).sum(axis=1)
     
-    def fwd(self, nmm, region_pars):
+    def fwd(self, nmm, region_pars, g):
         def tvb_dfun(buf, x, t):
             coupled_x = self.delay_apply(self.dh, t, buf[...,:self.nst_vars])
             coupling_term = coupled_x[:,:1] # firing rate coupling only for QIF
-
-            # concat state, nmm_p (eta, p_synap), and i_ext (coupling_term) for MLP
-            x = jnp.c_[x, region_pars, self.tvb_p['g']*coupling_term]
-            return nmm(x)
+            # jax.debug.print("coupling {x}", x=coupling_term[0])
+            return nmm(x, region_pars, g*coupling_term)
         return tvb_dfun
 
     def noise_fill(self, buf, nh, key):
-        # dWt =jax.random.normal(key, buf[nh+1:].shape)
         dWt = jax.random.normal(key, buf[nh+1:].transpose(0,2,1).shape)
         dWt = dWt.transpose(0,2,1)
         noise = self.gfun(dWt, jnp.sqrt(self.dt))
@@ -191,7 +217,8 @@ class TVB(nn.Module):
 
         # horizon is set at the start of the buffer because rolled at the start of chunk
         buf = buf.at[int(1/self.dt):,:,:self.nst_vars].add( initial_cond )
-        return buf    
+        return buf
+
 
     def chunk(self, module, buf, key):
         nh = int(self.dh.max_lag)
@@ -201,112 +228,82 @@ class TVB(nn.Module):
 
         # pass time count to the scanned integrator
         t_count = jnp.tile(jnp.arange(int(1/self.dt))[...,None,None], (84, 2)) # (buf_len, regions, state_vars)
-        return module(buf, dWt, t_count)
+        buf, rv = module(buf, dWt, t_count)
+        return buf, rv
 
-
-
+    def bold_monitor(self, module, bold_buf, rv, p=bold_default_theta):
+        t_count = jnp.tile(jnp.arange(rv.shape[0])[...,None, None,None], (4, 84, 2)) # (buf_len, regions, state_vars)
+        bold_buf, bold = module(bold_buf, rv, t_count)
+        s, f, v, q = bold_buf
+        return bold_buf, p.v0 * (p.k1 * (1. - q) + p.k2 * (1. - q / v) + p.k3 * (1. - v))
+    
     # def sim_metrics(self, rv):
 
 
     @nn.compact
-    def __call__(self, inputs,sim_len=30, eta=-5.,  batch_size = 8):
-        seed, eta = inputs
-        to_fit = self.param('to_fit',
-                        lambda key, x: self.tvb_p['to_fit'], # Initialization function
-                        self.tvb_p['to_fit'].shape)
+    def __call__(self, inputs, g, sim_len=400, seed=42):
         
-        region_pars = jnp.c_[-5. * jnp.ones((self.dh.n_from, 1)), jnp.ones((self.dh.n_from, 1))]
-        region_pars = region_pars.at[1,0].set(eta)
+        # i_ext = self.prepare_stimulus(x, i_ext, self.stvar)
+
+        # to_fit = self.param('to_fit',
+        #                 lambda key, x: self.tvb_p['to_fit'], # Initialization function
+        #                 self.tvb_p['to_fit'].shape)
+
+        
+        # region_pars = jnp.c_[-5. * jnp.ones((self.dh.n_from, 1)), jnp.ones((self.dh.n_from, 1))]
+        # region_pars = region_pars.at[3,:].set(inputs)
+        region_pars = inputs
         key = jax.random.PRNGKey(seed)
-        jax.debug.print("fit_num {x}", x=to_fit)
         buf = self.initialize_buffer(key)
         
-        nmm = lambda x: self.dfun(self.dfun_pars, x)
-        tvb_dfun = self.fwd(nmm, region_pars)
-        # jax.debug.print("key {x}", x=self.adhoc)
+        if self.ode:
+            pars = self.param('Nodes', lambda key: unfreeze(self.dfun_pars))
+            nmm = lambda x, xs, *args: self.dfun(pars, x, xs, scaling_factor=10, *args)
+            tvb_dfun = self.fwd(nmm, region_pars, g)
+        else:
+            nmm = lambda x, xs, *args: self.dfun(self.dfun_pars, x, xs, scaling_factor=10, *args)
+            tvb_dfun = self.fwd(nmm, region_pars, g)
+        # nmm = lambda x, xs, *args: self.dfun(x, xs, *args)
+        # tvb_dfun = self.fwd(nmm, region_pars, g)
+
+
         module = self.integrator(tvb_dfun, self.step, self.adhoc, self.dt, nh=int(self.dh.max_lag))
         run_chunk = nn.scan(self.chunk.__call__)
         run_sim = nn.scan(run_chunk)
         # sim_batch = nn.scan(run_sim)
-        
-        buf, rv = run_sim(module, buf, jax.random.split(key, (sim_len//2, 2000)))
 
-        # if type(batch_size)==int:
-        #     buf, rv = sim_batch(module, buf, jax.random.split(key, (batch_size, sim_len, 1000)))
-        # else:
-        #     buf, rv = sim_batch(module, buf, jax.random.split(key, (batch_size.astype(int), sim_len.astype(int), 1000)))
-        # return rv.squeeze().reshape(batch_size, -1, self.dh.n_from, self.nst_vars)
-        return rv.squeeze().reshape(-1, self.dh.n_from, self.nst_vars)
+        buf, rv = run_sim(module, buf, jax.random.split(key, (sim_len, 1000)))
+        dummy_adhoc_bold = lambda x: x
+        bold_dfun_p = lambda sfvq, x: bold_dfun(sfvq, x, bold_default_theta)
+        module = self.integrator(bold_dfun_p, Heun_step, dummy_adhoc_bold, self.dt/10000, nh=int(self.dh.max_lag), p=1)
+        run_bold = nn.scan(self.bold_monitor.__call__)
+
+        bold_buf = jnp.ones((4, self.dh.n_from, 1))
+        bold_buf = bold_buf.at[0].set(1.)
 
 
+        bold_buf, bold = run_bold(module, bold_buf, rv[...,0].reshape((-1, int(20000/self.dt), self.dh.n_from, 1)))
+        return bold
+        # return rv.squeeze().reshape(-1, self.dh.n_from, self.nst_vars), bold, bold_buf
 
-class MLP_Ode(nn.Module):
+
+class TVB_ODE(nn.Module):
     out_dim: int
     n_hiddens: Sequence[int]
     act_fn: Callable
-    step: Callable
-    dt: float = 1.0
-    additive: bool = False
-    kernel_init: Callable = jax.nn.initializers.normal(1e-6)
-    bias_init: Callable = jax.nn.initializers.normal(1e-6)
-    integrate: Optional[bool] = True
-    i_ext: Optional[bool] = True
-    stvar: Optional[int] = 0
-    p_mix: Optional[bool] = False
 
     def setup(self):
-        self.p_layers = [nn.Dense(feat, kernel_init=self.kernel_init) for feat in self.n_hiddens[0]] if self.p_mix else None
-        dims = self.n_hiddens[1:] if self.p_mix else self.n_hiddens
-        self.layers = [nn.Dense(feat, kernel_init=self.kernel_init, bias_init=self.bias_init) for feat in dims]
-        self.output = nn.Dense(self.out_dim, kernel_init=self.kernel_init, bias_init=self.bias_init)
+        self.Nodes = nn.vmap(
+                    Simple_MLP,
+                    in_axes=0, out_axes=0,
+                    variable_axes={'params': 0},
+                    split_rngs={'params': True},
+                    methods=["__call__"])(out_dim=self.out_dim, n_hiddens=self.n_hiddens, act_fn=self.act_fn, coupled=True)
 
-    def fwd(self, x, i_ext):
-        x, p = x
-        jax.debug.print("🤯 {x} 🤯", x=x.shape)
-        jax.debug.print("🤯 {x} 🤯", x=i_ext.shape)
-        if self.p_mix:
-            for layer in self.p_layers[:-1]:
-                p = layer(p)
-                p = self.act_fn(p)
-            p = self.p_layers[-1](p)
-        if self.additive:
-            x = jnp.c_[x, p] if self.i_ext else x
-        else:
-            x = jnp.c_[x, p, i_ext] if self.i_ext else x
-
-        for layer in self.layers:
-            x = layer(x)
-            x = self.act_fn(x)
-        x = self.output(x)
-        if self.additive:
-            x = x.at[:,1:2].set(x[:,1:2] + i_ext)
-        return x
-
-    def prepare_stimulus(self, x, external_i, stvar):
-        stimulus = jnp.zeros(x.shape)
-        # stimulus = stimulus.at[:,stvar,:].set(external_i) if isinstance(external_i, jnp.ndarray) else stimulus
-        return stimulus
-
-    @nn.compact
-    def __call__(self, inputs):
-        if not self.integrate:
-            (x, p), i_ext = inputs
-            deriv = self.fwd((x, p), i_ext)
-            return deriv
-
-        (x, p), i_ext = inputs if self.i_ext else (inputs, None)
-
-        integrate = Integrator(self.fwd, self.step, self.dt)
-        # initialize carry
-        xs = jnp.zeros_like(x)
-        # stimulus = self.prepare_stimulus(x, i_ext, self.stvar)
-        x = x[...,0]
-        jax.debug.print("🤯 x shape {x} 🤯", x=x.shape)
-        jax.debug.print("🤯 xs shape {x} 🤯", x=xs.shape)
-        jax.debug.print("🤯 iext shape {x} 🤯", x=i_ext.shape)
-        traj = integrate(x, xs, p, i_ext)
-
-        return traj[1]
+    def __call__(self, x, xs, *args):
+        y = self.Nodes(x, xs, *args)
+        return y
+        
 
 
 class Simple_MLP(nn.Module):
@@ -314,21 +311,21 @@ class Simple_MLP(nn.Module):
     n_hiddens: Sequence[int]
     act_fn: Callable
     kernel_init: Callable = jax.nn.initializers.normal(1e-6)
-    extra_p: bool = False
-    coupled: bool = True
+    coupled: bool = False
 
     def setup(self):
         self.layers = [nn.Dense(feat, kernel_init=self.kernel_init, bias_init=self.kernel_init) for feat in self.n_hiddens]
         self.output = nn.Dense(self.out_dim, kernel_init=self.kernel_init, bias_init=self.kernel_init)
     
     @nn.compact
-    def __call__(self, x):
-        # x = jnp.c_[x, i_ext] if self.coupled else x
+    def __call__(self, x, xs, *args, scaling_factor=1):
+        x = jnp.c_[x, xs]
+        x = jnp.c_[x, args[0]] if self.coupled else x
         for layer in self.layers:
             x = layer(x)
             x = self.act_fn(x)
         x = self.output(x)
-        return x
+        return x*scaling_factor
 
 
 class NeuralOdeWrapper(nn.Module):
@@ -336,27 +333,38 @@ class NeuralOdeWrapper(nn.Module):
     n_hiddens: Sequence[int]
     act_fn: Callable
     extra_p: int
+    dt: Optional[float] = 1.
     step: Optional[Callable] = Heun_step
     integrator: Optional[Callable] = Integrator
     network: Optional[Callable] = Simple_MLP
-    kernel_init: Callable = jax.nn.initializers.normal(10e-3)
     integrate: Optional[bool] = True
-    i_ext: Optional[bool] = True
+    coupled: Optional[bool] = False
     stvar: Optional[int] = 0
+    adhoc: Optional[Callable] = lambda x : x
+    
 
     @nn.compact
     def __call__(self, inputs):
-        x, p, i_ext = inputs
-        dfun = self.network(inputs, self.n_hiddens, self.act_fn, i_ext, extra_p=self.extra_p)
+        (x, i_ext) = inputs if self.coupled else (inputs, None)
+        dfun = self.network(self.out_dim, self.n_hiddens, self.act_fn, coupled=self.coupled)
+
+
         if not self.integrate:
-            deriv = dfun(inputs, i_ext)
+            deriv = dfun(inputs[0], inputs[1])
             return deriv
 
-        integrate = self.integrator(dfun, self.step)
-        xs = jnp.zeros_like(x) # initialize carry
+        in_ax = (0,0,0) if self.coupled else (0,0)
+        integrate = self.integrator(dfun, self.step, self.adhoc, self.dt, in_ax=in_ax, p=True)
+        
+        
+        # xs = jnp.zeros_like(x[:,:,:int(self.extra_p)]) # initialize carry
+        p = x[:,:,self.extra_p:] # initialize carry param filled
         # i_ext = self.prepare_stimulus(x, i_ext, self.stvar)
-        x = x[...,0]
-        return integrate(x, xs, p, i_ext)[1]
+        t_count = jnp.tile(jnp.arange(x.shape[0])[...,None,None], (x.shape[1], x.shape[2])) # (length, train_samples, state_vars)
+        
+        x = x[0,:,:int(self.extra_p)]
+        
+        return integrate(x, p, t_count, i_ext)[1]
 
 
 class Encoder(nn.Module):
@@ -429,4 +437,74 @@ class Autoencoder(nn.Module):
             y = self.integrate(encoded, L)
 
         return y
+
+
+
+# class MLP_Ode(nn.Module):
+#     out_dim: int
+#     n_hiddens: Sequence[int]
+#     act_fn: Callable
+#     step: Callable
+#     dt: float = 1.0
+#     additive: bool = False
+#     kernel_init: Callable = jax.nn.initializers.normal(1e-6)
+#     bias_init: Callable = jax.nn.initializers.normal(1e-6)
+#     integrate: Optional[bool] = True
+#     i_ext: Optional[bool] = True
+#     stvar: Optional[int] = 0
+#     p_mix: Optional[bool] = False
+
+#     def setup(self):
+#         self.p_layers = [nn.Dense(feat, kernel_init=self.kernel_init) for feat in self.n_hiddens[0]] if self.p_mix else None
+#         dims = self.n_hiddens[1:] if self.p_mix else self.n_hiddens
+#         self.layers = [nn.Dense(feat, kernel_init=self.kernel_init, bias_init=self.bias_init) for feat in dims]
+#         self.output = nn.Dense(self.out_dim, kernel_init=self.kernel_init, bias_init=self.bias_init)
+
+#     def fwd(self, x, i_ext):
+#         x, p = x
+#         jax.debug.print("🤯 {x} 🤯", x=x.shape)
+#         jax.debug.print("🤯 {x} 🤯", x=i_ext.shape)
+#         if self.p_mix:
+#             for layer in self.p_layers[:-1]:
+#                 p = layer(p)
+#                 p = self.act_fn(p)
+#             p = self.p_layers[-1](p)
+#         if self.additive:
+#             x = jnp.c_[x, p] if self.i_ext else x
+#         else:
+#             x = jnp.c_[x, p, i_ext] if self.i_ext else x
+
+#         for layer in self.layers:
+#             x = layer(x)
+#             x = self.act_fn(x)
+#         x = self.output(x)
+#         if self.additive:
+#             x = x.at[:,1:2].set(x[:,1:2] + i_ext)
+#         return x
+
+#     def prepare_stimulus(self, x, external_i, stvar):
+#         stimulus = jnp.zeros(x.shape)
+#         # stimulus = stimulus.at[:,stvar,:].set(external_i) if isinstance(external_i, jnp.ndarray) else stimulus
+#         return stimulus
+
+#     @nn.compact
+#     def __call__(self, inputs):
+#         if not self.integrate:
+#             (x, p), i_ext = inputs
+#             deriv = self.fwd((x, p), i_ext)
+#             return deriv
+
+#         (x, p), i_ext = inputs if self.i_ext else (inputs, None)
+
+#         integrate = Integrator(self.fwd, self.step, self.dt)
+#         # initialize carry
+#         xs = jnp.zeros_like(x)
+#         # stimulus = self.prepare_stimulus(x, i_ext, self.stvar)
+#         x = x[...,0]
+#         jax.debug.print("🤯 x shape {x} 🤯", x=x.shape)
+#         jax.debug.print("🤯 xs shape {x} 🤯", x=xs.shape)
+#         jax.debug.print("🤯 iext shape {x} 🤯", x=i_ext.shape)
+#         traj = integrate(x, xs, p, i_ext)
+
+#         return traj[1]
 

--- a/vbjax/ml_models.py
+++ b/vbjax/ml_models.py
@@ -4,7 +4,9 @@ from typing import Callable, Sequence, Optional
 from jax._src.prng import PRNGKeyArrayImpl
 import jax.random as random
 from vbjax.layers import MaskedMLP, OutputLayer, create_degrees, create_masks
-
+from vbjax.loops import make_ode_flax, heun_step
+import jax
+from flax.linen.initializers import zeros
 
 class GaussianMADE(nn.Module):
     key: PRNGKeyArrayImpl
@@ -66,5 +68,221 @@ class MAF(nn.Module):
 
         for made in self.mades[::-1]:
             x = made.gen(key, shape, x)
-
         return x
+
+
+
+class Heun_step(nn.Module):
+    dfun: Callable
+    stvar: Optional[int] = 0
+    external_i: Optional[int] = False
+    adhoc: Optional[Callable] = None
+
+    @nn.compact
+    def __call__(self, x, xs, p, i_ext):
+        tmap = jax.tree_util.tree_map
+        dt = 1.
+        d1 = self.dfun((x, p), i_ext)
+        xi = tmap(lambda x,d: x + dt*d, x, d1)
+        # xi = tmap(lambda x,d,a: x + dt*d + a, x, d1, stimulus)
+
+        d2 = self.dfun((xi, p), i_ext)
+        nx = tmap(lambda x, d1,d2: x + dt*0.5*(d1 + d2), x, d1, d2)
+        # nx = tmap(lambda x, d1,d2,a: x + dt*0.5*(d1 + d2) + a, x, d1, d2, stimulus)
+        return nx, x
+
+
+class Integrator(nn.Module):
+    dfun: Callable
+    step: Callable
+    stvar: Optional[int] = 0
+    adhoc: Optional[Callable] = None
+
+    @nn.compact
+    def __call__(self, c, xs, p=None, external_i=None):
+        STEP = nn.scan(self.step,
+                        variable_broadcast="params",
+                        split_rngs={"params": False},
+                        in_axes=(2, 2, 2),
+                        out_axes=2
+                        )
+        return STEP(self.dfun, self.stvar, self.adhoc)(c, xs, p, external_i)
+
+
+class MLP_Ode(nn.Module):
+    out_dim: int
+    n_hiddens: Sequence[int]
+    act_fn: Callable
+    step: Callable
+    kernel_init: Callable = jax.nn.initializers.normal(1e-6)
+    bias_init: Callable = jax.nn.initializers.normal(1e-6)
+    integrate: Optional[bool] = True
+    i_ext: Optional[bool] = True
+    stvar: Optional[int] = 0
+    p_mix: Optional[bool] = False
+
+    def setup(self):
+        self.p_layers = [nn.Dense(feat, kernel_init=self.kernel_init) for feat in self.n_hiddens[0]] if self.p_mix else None
+        dims = self.n_hiddens[1:] if self.p_mix else self.n_hiddens
+        self.layers = [nn.Dense(feat, kernel_init=self.kernel_init, bias_init=self.bias_init) for feat in dims]
+        self.output = nn.Dense(self.out_dim, kernel_init=self.kernel_init, bias_init=self.bias_init)
+
+
+    def fwd(self, x, i_ext):
+        x, p = x
+        if self.p_mix:
+            for layer in self.p_layers[:-1]:
+                p = layer(p)
+                p = self.act_fn(p)
+            p = self.p_layers[-1](p)
+        x = jnp.c_[x, p, i_ext] if self.i_ext else x
+
+        for layer in self.layers:
+            x = layer(x)
+            x = self.act_fn(x)
+        x = self.output(x)
+        return x
+
+    def prepare_stimulus(self, x, external_i, stvar):
+        stimulus = jnp.zeros(x.shape)
+        # stimulus = stimulus.at[:,stvar,:].set(external_i) if isinstance(external_i, jnp.ndarray) else stimulus
+        return stimulus
+
+    @nn.compact
+    def __call__(self, inputs):
+        if not self.integrate:
+            (x, p), i_ext = inputs
+            deriv = self.fwd((x, p), i_ext)
+            return deriv
+
+        (x, p), i_ext = inputs if self.i_ext else (inputs, None)
+
+        integrate = Integrator(self.fwd, self.step)
+        # initialize carry
+        xs = jnp.zeros_like(x)
+        # stimulus = self.prepare_stimulus(x, i_ext, self.stvar)
+        x = x[...,0]
+        traj = integrate(x, xs, p, i_ext)
+
+        return traj[1]
+
+
+
+class Simple_MLP(nn.Module):
+    out_dim: int
+    n_hiddens: Sequence[int]
+    act_fn: Callable
+    kernel_init: Callable = jax.random.normal
+    extra_p: bool = False
+
+    @nn.compact
+    def __call__(self, x, i_ext):
+        layers = [nn.Dense(feat, kernel_init=self.kernel_init*1e-6, bias_init=self.kernel_init*1e-6) for feat in self.n_hiddens]
+        output = nn.Dense(self.out_dim, kernel_init=self.kernel_init*1e-6, bias_init=self.kernel_init*1e-6)
+        x = jnp.c_[x[0], x[1]] if self.extra_p else x[0]
+        for layer in layers:
+            x = layer(x)
+            x = self.act_fn(x)
+        x = output(x)
+        return x
+
+
+class NeuralOdeWrapper(nn.Module):
+    out_dim: int
+    n_hiddens: Sequence[int]
+    act_fn: Callable
+    extra_p: int
+    step: Optional[Callable] = Heun_step
+    integrator: Optional[Callable] = Integrator
+    network: Optional[Callable] = Simple_MLP
+    kernel_init: Callable = jax.nn.initializers.normal(10e-3)
+    integrate: Optional[bool] = True
+    i_ext: Optional[bool] = True
+    stvar: Optional[int] = 0
+
+    @nn.compact
+    def __call__(self, inputs):
+        x, p, i_ext = inputs
+        dfun = self.network(inputs, self.n_hiddens, self.act_fn, i_ext, extra_p=self.extra_p)
+        if not self.integrate:
+            deriv = dfun(inputs, i_ext)
+            return deriv
+
+        integrate = self.integrator(dfun, self.step)
+        xs = jnp.zeros_like(x) # initialize carry
+        # i_ext = self.prepare_stimulus(x, i_ext, self.stvar)
+        x = x[...,0]
+        return integrate(x, xs, p, i_ext)[1]
+
+
+
+class Encoder(nn.Module):
+    in_dim: int
+    latent_dim: int
+    act_fn: Callable
+    n_hiddens: Sequence[int] = None
+
+    def setup(self, n_hiddens: Optional[Sequence] = None):
+        n_hiddens = n_hiddens[::-1] if n_hiddens else [self.in_dim, 4*self.latent_dim, 2*self.latent_dim, self.latent_dim][::-1]
+        self.layers = [nn.Dense(feat) for feat in n_hiddens]
+
+    def __call__(self, inputs):
+        x = inputs
+        for layer in self.layers:
+            x = layer(x)
+            x = self.act_fn(x)
+        return x
+
+
+class Decoder(nn.Module):
+    in_dim: int
+    latent_dim: int
+    act_fn: Callable
+    n_hiddens: Sequence[int] = None
+
+    def setup(self, n_hiddens: Optional[Sequence] = None):
+        n_hiddens = n_hiddens[::-1] if n_hiddens else [self.in_dim, 4*self.latent_dim, 2*self.latent_dim, self.latent_dim][::-1]
+        self.layers = [nn.Dense(feat) for feat in n_hiddens]
+
+    def __call__(self, inputs):
+        x = inputs
+        for layer in self.layers[:-1]:
+            x = layer(x)
+            x = self.act_fn(x)
+        x = self.layers[-1](x)
+        return x
+
+class Autoencoder(nn.Module):
+    latent_dim: int
+    encoder_act_fn: Callable
+    decoder_act_fn: Callable
+    ode_act_fn: Callable
+    ode: bool = False
+    n_hiddens: Sequence[int] = None
+    kernel_init: Callable = jax.nn.initializers.normal(10e-3)
+    step: Optional[Callable] = Heun_step
+    integrator: Optional[Callable] = Integrator
+    network: Optional[Callable] = Simple_MLP
+    i_ext: Optional[bool] = True
+    ode_n_hiddens: Optional[Sequence] = None
+
+    def integrate(self, encoded, L):
+        xs =  jnp.ones((encoded.shape[0], encoded.shape[1], L)) # initialize carry
+        dfun = self.network(encoded.shape[1], self.ode_n_hiddens, self.ode_act_fn)
+        integrator = self.integrator(dfun, self.step)
+        return integrator(encoded, xs)[1]
+
+    @nn.compact
+    def __call__(self, inputs):
+        L = inputs.shape[-1]
+
+        encoder = Encoder(inputs.shape[1], self.latent_dim, self.encoder_act_fn, self.n_hiddens)
+        encoded = encoder(inputs[:,:,0]) if self.ode else encoder(inputs) # (N, )
+
+        decoder = Decoder(inputs.shape[1], self.latent_dim, self.decoder_act_fn)
+        y = decoder(encoded)
+        if self.ode:
+            y = self.integrate(encoded, L)
+
+        return y
+

--- a/vbjax/ml_models.py
+++ b/vbjax/ml_models.py
@@ -1,0 +1,43 @@
+import jax.numpy as jnp
+from flax import linen as nn
+from typing import Callable, Sequence
+from jax._src.prng import PRNGKeyArrayImpl
+import jax.random as random
+from vbjax.layers import MaskedMLP, OutputLayer, create_degrees, create_masks
+
+
+class GaussianMADE(nn.Module):
+    key: PRNGKeyArrayImpl
+    in_dim: int
+    n_hiddens: Sequence[int]
+    act_fn: Callable
+
+    def setup(self):
+        self.degrees = create_degrees(self.key, self.in_dim, self.n_hiddens, input_order='sequential', mode='sequential')
+        self.masks, self.out_mask = create_masks(self.degrees)
+        self.mlp = MaskedMLP(self.n_hiddens, self.act_fn, self.masks)
+        self.output_layer = OutputLayer(self.in_dim, self.out_mask)
+
+    
+    def __call__(self, inputs):
+        h = self.mlp(inputs) 
+        m, logp = self.output_layer(h) 
+        return m, logp
+
+
+    def gen(self, key, shape, u=None):
+        """
+        Generate samples from made. Requires as many evaluations as number of inputs.
+        :param n_samples: number of samples
+        :param u: random numbers to use in generating samples; if None, new random numbers are drawn
+        :return: samples
+        """
+        x = jnp.zeros(shape)
+        u = random.normal(key, shape) if u is None else u
+
+        for i in range(1, shape[1] + 1):
+            h = self.mlp(x)
+            m, logp = self.output_layer(h) 
+            idx = jnp.argwhere(self.degrees[0] == i)[0, 0]
+            x = x.at[:, idx].set(m[:, idx] + jnp.exp(jnp.minimum(-0.5 * logp[:, idx], 10.0)) * u[:, idx])
+        return x

--- a/vbjax/noise_generator.py
+++ b/vbjax/noise_generator.py
@@ -1,0 +1,45 @@
+import jax.numpy as np
+import matplotlib.pyplot as plt
+import jax 
+
+
+def plot_spectrum(s):
+    f = np.fft.rfftfreq(len(s))
+    return plt.loglog(f, np.abs(np.fft.rfft(s)))[0]
+
+def noise_psd(shape, key, sigma=1, psd = lambda f: 1, **kwargs):
+        X_white = np.fft.rfft(jax.random.normal(key, shape)*sigma)
+        S = psd(np.fft.rfftfreq(shape[1]), **kwargs)
+        # Normalize S
+        S = S / np.sqrt(np.mean(S**2))
+        X_shaped = X_white * S
+        return np.fft.irfft(X_shaped)
+
+def PSDGenerator(f, *args, **kwargs):
+    return lambda shape, *args, **kwargs,: noise_psd(shape, *args, **kwargs, psd=f)
+
+@PSDGenerator
+def white_noise(f):
+    return 1
+
+@PSDGenerator
+def blue_noise(f):
+    return np.sqrt(f)
+
+@PSDGenerator
+def violet_noise(f):
+    return f
+
+@PSDGenerator
+def brownian_noise(f):
+    return 1/np.where(f == 0, float('inf'), f)
+
+@PSDGenerator
+def pink_noise(f):
+    return 1/np.where(f == 0, float('inf'), np.sqrt(f))
+
+@PSDGenerator
+def spectral_exponent(f, exponent=1):
+    return 1/np.where(f == 0, float('inf'), f**exponent)
+
+

--- a/vbjax/noise_generator.py
+++ b/vbjax/noise_generator.py
@@ -2,12 +2,37 @@ import jax.numpy as np
 import matplotlib.pyplot as plt
 import jax 
 
-
-def plot_spectrum(s):
-    f = np.fft.rfftfreq(len(s))
-    return plt.loglog(f, np.abs(np.fft.rfft(s)))[0]
-
 def noise_psd(shape, key, sigma=1, psd = lambda f: 1, **kwargs):
+        """Generate noise given desired power spectrum
+
+        Parameters
+        ==========
+        shape : tuple
+            (n_nodes, t_steps)
+        key : function
+            jax.random.PRNGKey()
+        sigma (optional kwarg): float
+            Standard deviation, defaults to 1
+        exponent (optional kwarg) : float
+            Spectral exponent for 1/f noise, defaults to 1
+            
+        Returns
+        =======
+        noise_stream : (n_nodes, t_steps) array
+            
+        Notes
+        =====
+        Example usage for white noise and 1/f noise
+
+        >>> import vbjax as vb, import jax
+        >>> key = jax.random.PRNGKey(seed)
+
+        >>> vbjax.noise_generator.white_noise((1,1000), key, sigma=2)
+        
+        >>> vbjax.noise_generator.spectral_exponent((84,10000), key, sigma=2, exponent=1.1)
+
+        """
+
         X_white = np.fft.rfft(jax.random.normal(key, shape)*sigma)
         S = psd(np.fft.rfftfreq(shape[1]), **kwargs)
         # Normalize S
@@ -15,7 +40,7 @@ def noise_psd(shape, key, sigma=1, psd = lambda f: 1, **kwargs):
         X_shaped = X_white * S
         return np.fft.irfft(X_shaped)
 
-def PSDGenerator(f, *args, **kwargs):
+def PSDGenerator(f):
     return lambda shape, *args, **kwargs,: noise_psd(shape, *args, **kwargs, psd=f)
 
 @PSDGenerator

--- a/vbjax/noise_generator.py
+++ b/vbjax/noise_generator.py
@@ -2,7 +2,27 @@ import jax.numpy as np
 import matplotlib.pyplot as plt
 import jax 
 
-def noise_psd(shape, key, sigma=1, psd = lambda f: 1, **kwargs):
+
+def white_noise(f): 
+    return f
+
+def blue_noise(f):
+    return np.sqrt(f)
+
+def violet_noise(f):
+    return f
+
+def brownian_noise(f):
+    return 1/np.where(f == 0, float('inf'), f)
+
+def pink_noise(f):
+    return 1/np.where(f == 0, float('inf'), np.sqrt(f))
+
+def spectral_exponent(f, exponent=1):
+    return 1/np.where(f == 0, float('inf'), f**exponent)
+
+
+def make_noise_generator(psd = lambda f: 1):
         """Generate noise given desired power spectrum
 
         Parameters
@@ -27,44 +47,16 @@ def noise_psd(shape, key, sigma=1, psd = lambda f: 1, **kwargs):
         >>> import vbjax as vb, import jax
         >>> key = jax.random.PRNGKey(seed)
 
-        >>> vbjax.noise_generator.white_noise((1,1000), key, sigma=2)
-        
-        >>> vbjax.noise_generator.spectral_exponent((84,10000), key, sigma=2, exponent=1.1)
-
         """
+        def gen(key, shape, sigma=1, **kwargs):
+            # sigma = kwargs['sigma'] or 1
+            X_white = np.fft.rfft(jax.random.normal(key, shape)*sigma)
+            S = psd(np.fft.rfftfreq(shape[1]), **kwargs)
+            S = S / np.sqrt(np.mean(S**2))
+            X_shaped = X_white * S
+            return np.fft.irfft(X_shaped)
+        return gen
 
-        X_white = np.fft.rfft(jax.random.normal(key, shape)*sigma)
-        S = psd(np.fft.rfftfreq(shape[1]), **kwargs)
-        # Normalize S
-        S = S / np.sqrt(np.mean(S**2))
-        X_shaped = X_white * S
-        return np.fft.irfft(X_shaped)
 
-def PSDGenerator(f):
-    return lambda shape, *args, **kwargs,: noise_psd(shape, *args, **kwargs, psd=f)
-
-@PSDGenerator
-def white_noise(f):
-    return 1
-
-@PSDGenerator
-def blue_noise(f):
-    return np.sqrt(f)
-
-@PSDGenerator
-def violet_noise(f):
-    return f
-
-@PSDGenerator
-def brownian_noise(f):
-    return 1/np.where(f == 0, float('inf'), f)
-
-@PSDGenerator
-def pink_noise(f):
-    return 1/np.where(f == 0, float('inf'), np.sqrt(f))
-
-@PSDGenerator
-def spectral_exponent(f, exponent=1):
-    return 1/np.where(f == 0, float('inf'), f**exponent)
 
 

--- a/vbjax/train.py
+++ b/vbjax/train.py
@@ -1,0 +1,83 @@
+from flax.training import train_state
+import jax.numpy as jnp
+import jax.random as random
+from flax import linen as nn
+from vbjax.ml_models import GaussianMADE
+import optax
+import matplotlib.pyplot as plt
+import numpy as np
+from vbjax.train_utils import eval_MADE, train_step, grad_func
+
+def train_and_evaluate(model, X, config):
+    rng = random.key(0)
+    rng, key = random.split(rng)
+
+    init_data = jnp.ones((config['batch_size'], config['in_dim']), jnp.float32)
+    params = model.init(key, init_data)['params']
+
+    state = train_state.TrainState.create(
+        apply_fn=model.apply,
+        params=params,
+        tx=optax.adam(config['learning_rate']),
+    )
+
+    print(state.params['mlp']['hidden_0']['kernel'][0,:])
+
+    for i, epoch in enumerate(range(config['num_epochs'])):
+        if i%5==0:
+          ms, logp = model.apply({'params': state.params}, X)
+          loss, u_distro = eval_MADE(
+            model, state.params, X, key, shape=(20000,2),
+          )
+          print('eval epoch: {}, loss: {}'.format(i + 1, loss))
+          U = jnp.exp(.5 * logp) * (X - ms)
+          L = -0.5 * (X.shape[0] * jnp.log(2 * jnp.pi) + jnp.sum(U ** 2 - logp, axis=1))
+          fig, (ax1, ax2, ax3, ax4) = plt.subplots(1, 4, figsize=(14,4))
+          ax1.scatter(np.array(X[:,0]), np.array(X[:,1]))
+          cs = ax2.scatter(np.array(U[:,0]), np.array(U[:,1]), c=L, vmin=L.min(), vmax=L.max())
+          ax3.scatter(np.array(ms[:,0]), np.array(ms[:,1]))
+          ax3.set_title('means')
+          his = ax4.hist2d(np.array(u_distro[:,0]), np.array(u_distro[:,1]), bins=30, density=True, vmax=.03)
+          fig.colorbar(his[3], ax=ax4)
+          ax4.set_title('logp')
+          plt.colorbar(cs, ax=ax2)
+          fig.tight_layout()
+          plt.show()
+        for _ in range(100):
+          batch = X[i*config['batch_size']:(i+1)*config['batch_size']]
+          rng, key = random.split(rng)
+          state = train_step(state, batch)
+        
+        ms, logp = model.apply({'params': state.params}, batch)
+        loss, u_distro = eval_MADE(
+        model, state.params, batch, key
+        )
+        print('eval epoch: {}, loss: {}'.format(i + 1, loss))
+        print(jnp.linalg.norm(grad_func(state, batch)['mlp']['hidden_0']['kernel']))
+
+    return state, model
+
+
+
+config = {}
+config['learning_rate'] = .003
+config['in_dim'] = 2
+config['batch_size'] = 256
+config['num_epochs'] = 60
+config['n_hiddens'] = [5, 5]
+
+
+key1, key2 = random.split(random.key(0), 2)
+x2 = 4 * random.normal(key1, (config['batch_size']*100,))
+x1 = (.25*x2**2) + random.normal(key2, (config['batch_size']*100,))
+X = jnp.vstack([x2, x1]).T
+
+# key1, key2 = random.split(random.key(0), 2)
+# x2 = 3 * random.normal(key1, (config['batch_size']*100,))
+# x1 = x2 + random.normal(key2, (config['batch_size']*100,))
+# X = jnp.vstack([x2, x1]).T
+
+
+model=GaussianMADE(random.PRNGKey(42), 2, config['n_hiddens'], act_fn=nn.relu)
+state_f, mdl = train_and_evaluate(model, X, config)
+

--- a/vbjax/train.py
+++ b/vbjax/train.py
@@ -2,11 +2,11 @@ from flax.training import train_state
 import jax.numpy as jnp
 import jax.random as random
 from flax import linen as nn
-from vbjax.ml_models import GaussianMADE
+from vbjax.ml_models import GaussianMADE, MAF
 import optax
 import matplotlib.pyplot as plt
 import numpy as np
-from vbjax.train_utils import eval_MADE, train_step, grad_func
+from vbjax.train_utils import eval_model, train_step, grad_func, log_likelihood_MADE
 
 def train_and_evaluate(model, X, config):
     rng = random.key(0)
@@ -24,46 +24,44 @@ def train_and_evaluate(model, X, config):
     print(state.params['mlp']['hidden_0']['kernel'][0,:])
 
     for i, epoch in enumerate(range(config['num_epochs'])):
-        if i%5==0:
+        if i%10==0:
           ms, logp = model.apply({'params': state.params}, X)
-          loss, u_distro = eval_MADE(
-            model, state.params, X, key, shape=(20000,2),
+          loss, u_distro = eval_model(
+            model, state.params, X, key, log_likelihood_MADE, shape=(20000,2),
           )
           print('eval epoch: {}, loss: {}'.format(i + 1, loss))
           U = jnp.exp(.5 * logp) * (X - ms)
           L = -0.5 * (X.shape[0] * jnp.log(2 * jnp.pi) + jnp.sum(U ** 2 - logp, axis=1))
-          fig, (ax1, ax2, ax3, ax4) = plt.subplots(1, 4, figsize=(14,4))
+          fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(14,4))
           ax1.scatter(np.array(X[:,0]), np.array(X[:,1]))
           cs = ax2.scatter(np.array(U[:,0]), np.array(U[:,1]), c=L, vmin=L.min(), vmax=L.max())
-          ax3.scatter(np.array(ms[:,0]), np.array(ms[:,1]))
-          ax3.set_title('means')
-          his = ax4.hist2d(np.array(u_distro[:,0]), np.array(u_distro[:,1]), bins=30, density=True, vmax=.03)
-          fig.colorbar(his[3], ax=ax4)
-          ax4.set_title('logp')
+          his = ax3.hist2d(np.array(u_distro[:,0]), np.array(u_distro[:,1]), bins=30, density=True, vmax=.03)
+          fig.colorbar(his[3], ax=ax3)
+          ax3.set_title('logp')
           plt.colorbar(cs, ax=ax2)
           fig.tight_layout()
           plt.show()
         for _ in range(100):
           batch = X[i*config['batch_size']:(i+1)*config['batch_size']]
           rng, key = random.split(rng)
-          state = train_step(state, batch)
+          state = train_step(state, batch, log_likelihood_MADE)
         
         ms, logp = model.apply({'params': state.params}, batch)
-        loss, u_distro = eval_MADE(
-        model, state.params, batch, key
+        loss, u_distro = eval_model(
+        model, state.params, batch, key, log_likelihood_MADE
         )
         print('eval epoch: {}, loss: {}'.format(i + 1, loss))
-        print(jnp.linalg.norm(grad_func(state, batch)['mlp']['hidden_0']['kernel']))
+        # print(jnp.linalg.norm(grad_func(state, batch)['mlp']['hidden_0']['kernel']))
 
     return state, model
 
 
 
 config = {}
-config['learning_rate'] = .003
+config['learning_rate'] = .01
 config['in_dim'] = 2
 config['batch_size'] = 256
-config['num_epochs'] = 60
+config['num_epochs'] = 120
 config['n_hiddens'] = [5, 5]
 
 
@@ -80,4 +78,5 @@ X = jnp.vstack([x2, x1]).T
 
 model=GaussianMADE(random.PRNGKey(42), 2, config['n_hiddens'], act_fn=nn.relu)
 state_f, mdl = train_and_evaluate(model, X, config)
+
 

--- a/vbjax/train.py
+++ b/vbjax/train.py
@@ -3,10 +3,21 @@ import jax.numpy as jnp
 import jax.random as random
 from flax import linen as nn
 from vbjax.ml_models import GaussianMADE, MAF
-import optax
+import optax, jax
 import matplotlib.pyplot as plt
 import numpy as np
-from vbjax.train_utils import eval_model, train_step, grad_func, log_likelihood_MADE
+from vbjax.train_utils import eval_model, grad_func, log_likelihood_MAF
+
+def train_step(state, batch, loss_f):
+  def loss_fn(params):
+    output = state.apply_fn(
+        {'params': params}, batch,
+    )
+    loss = loss_f(output, batch).mean()
+    return loss
+  grads = jax.grad(loss_fn)(state.params)
+  return state.apply_gradients(grads=grads)
+
 
 def train_and_evaluate(model, X, config):
     rng = random.key(0)
@@ -21,36 +32,38 @@ def train_and_evaluate(model, X, config):
         tx=optax.adam(config['learning_rate']),
     )
 
-    print(state.params['mlp']['hidden_0']['kernel'][0,:])
+    # print(state.params['mlp']['hidden_0']['kernel'][0,:])
+    batch_size = config['batch_size']
+    BATCHES = np.split(np.random.choice(np.arange(len(X)), (len(X)//batch_size)*batch_size), (len(X)//batch_size))
 
     for i, epoch in enumerate(range(config['num_epochs'])):
         if i%10==0:
-          ms, logp = model.apply({'params': state.params}, X)
+          u, logp = state.apply_fn({'params': state.params}, X)
           loss, u_distro = eval_model(
-            model, state.params, X, key, log_likelihood_MADE, shape=(20000,2),
+            model, state.params, X, key, log_likelihood_MAF, shape=(20000,2),
           )
           print('eval epoch: {}, loss: {}'.format(i + 1, loss))
-          U = jnp.exp(.5 * logp) * (X - ms)
-          L = -0.5 * (X.shape[0] * jnp.log(2 * jnp.pi) + jnp.sum(U ** 2 - logp, axis=1))
+          # U = jnp.exp(.5 * logp) * (X - ms)
+          # L = -0.5 * (X.shape[1] * jnp.log(2 * jnp.pi) + jnp.sum(U ** 2 - logp, axis=1))
           fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(14,4))
           ax1.scatter(np.array(X[:,0]), np.array(X[:,1]))
-          cs = ax2.scatter(np.array(U[:,0]), np.array(U[:,1]), c=L, vmin=L.min(), vmax=L.max())
+          cs = ax2.scatter(np.array(u[:,0]), np.array(u[:,1]), c=loss, vmin=loss.min(), vmax=loss.max())
           his = ax3.hist2d(np.array(u_distro[:,0]), np.array(u_distro[:,1]), bins=30, density=True, vmax=.03)
           fig.colorbar(his[3], ax=ax3)
           ax3.set_title('logp')
           plt.colorbar(cs, ax=ax2)
           fig.tight_layout()
           plt.show()
-        for _ in range(100):
-          batch = X[i*config['batch_size']:(i+1)*config['batch_size']]
+
+        for j, batch_i in enumerate(BATCHES):
+          batch = X[batch_i]
+          # batch = X[i*config['batch_size']:(i+1)*config['batch_size']]
           rng, key = random.split(rng)
-          state = train_step(state, batch, log_likelihood_MADE)
-        
-        ms, logp = model.apply({'params': state.params}, batch)
+          state = train_step(state, batch, log_likelihood_MAF)
         loss, u_distro = eval_model(
-        model, state.params, batch, key, log_likelihood_MADE
-        )
-        print('eval epoch: {}, loss: {}'.format(i + 1, loss))
+            model, state.params, X, key, log_likelihood_MAF, shape=(20000,2),
+          )
+        print('eval epoch: {}, loss: {}'.format(i + 1, loss.mean()))
         # print(jnp.linalg.norm(grad_func(state, batch)['mlp']['hidden_0']['kernel']))
 
     return state, model
@@ -58,10 +71,10 @@ def train_and_evaluate(model, X, config):
 
 
 config = {}
-config['learning_rate'] = .01
+config['learning_rate'] = .003
 config['in_dim'] = 2
 config['batch_size'] = 256
-config['num_epochs'] = 120
+config['num_epochs'] = 60
 config['n_hiddens'] = [5, 5]
 
 
@@ -76,7 +89,21 @@ X = jnp.vstack([x2, x1]).T
 # X = jnp.vstack([x2, x1]).T
 
 
-model=GaussianMADE(random.PRNGKey(42), 2, config['n_hiddens'], act_fn=nn.relu)
+model=MAF(random.PRNGKey(42), 2, config['n_hiddens'], act_fn=nn.relu, n_mades=4)
 state_f, mdl = train_and_evaluate(model, X, config)
 
 
+def nnet_fn(X):
+  ms, logp = mdl.apply({'params': state_f.params}, X)
+  u = jnp.exp(.5 * logp) * (X - ms)
+  L = -0.5 * (X.shape[1] * jnp.log(2 * jnp.pi) + jnp.sum(u ** 2 - logp, axis=1))
+  return u, L
+
+
+x = y = jnp.linspace(-30, 30, 500)
+xx, yy = jnp.meshgrid(x, y)
+X_test = jnp.vstack([xx.ravel(), yy.ravel()]).T
+u, L = nnet_fn(X_test)
+L = L.reshape(500,500)
+plt.imshow(np.exp(L))
+plt.show()

--- a/vbjax/train_utils.py
+++ b/vbjax/train_utils.py
@@ -7,7 +7,8 @@ def log_likelihood_MADE(ms, logp, x, *args):
    return -(- 0.5 * (x.shape[1] * jnp.log(2 * jnp.pi) + jnp.sum(u ** 2 - logp, axis=1)))
 
 
-def log_likelihood_MAF(u, logdet_dudx, *arg):
+def log_likelihood_MAF(x, *arg):
+    u, logdet_dudx = x
     return -(- 0.5 * u.shape[1] * jnp.log(2 * jnp.pi) - 0.5 * jnp.sum(u ** 2, axis=1) + logdet_dudx)
 
 def mse_ode(traj, x, *arg):
@@ -35,7 +36,7 @@ def eval_model(model, params, batch, key, loss_fn, shape=None):
   shape = shape if shape else batch.shape
   def eval_model(model):
     output = model(batch)
-    loss = loss_fn(output, batch).mean()
+    loss = loss_fn(output, batch)#.mean()
     u_sample = model.gen(key, shape)
     return loss, u_sample
   return nn.apply(eval_model, model)({'params': params})

--- a/vbjax/train_utils.py
+++ b/vbjax/train_utils.py
@@ -4,11 +4,11 @@ from flax import linen as nn
 
 def log_likelihood_MADE(ms, logp, x, *args):
    u = jnp.exp(.5 * logp) * (x - ms)
-   return -0.5 * (x.shape[0] * jnp.log(2 * jnp.pi) + jnp.sum(u ** 2 - logp, axis=1))
+   return -0.5 * (x.shape[1] * jnp.log(2 * jnp.pi) + jnp.sum(u ** 2 - logp, axis=1))
 
 
 def log_likelihood_MAF(u, logdet_dudx, *arg):
-    return -0.5 * u.shape[0] * jnp.log(2 * jnp.pi) - 0.5 * jnp.sum(u ** 2, axis=1) + logdet_dudx
+    return -0.5 * u.shape[1] * jnp.log(2 * jnp.pi) - 0.5 * jnp.sum(u ** 2, axis=1) + logdet_dudx
 
 
 def eval_model(model, params, batch, key, likelihood_fn, shape=None):

--- a/vbjax/train_utils.py
+++ b/vbjax/train_utils.py
@@ -2,38 +2,42 @@ import jax
 import jax.numpy as jnp
 from flax import linen as nn
 
-def log_likelihood(ms, logp, x):
+def log_likelihood_MADE(ms, logp, x, *args):
    u = jnp.exp(.5 * logp) * (x - ms)
    return -0.5 * (x.shape[0] * jnp.log(2 * jnp.pi) + jnp.sum(u ** 2 - logp, axis=1))
 
 
-def eval_MADE(made, params, batch, key, shape=None):
+def log_likelihood_MAF(u, logdet_dudx, *arg):
+    return -0.5 * u.shape[0] * jnp.log(2 * jnp.pi) - 0.5 * jnp.sum(u ** 2, axis=1) + logdet_dudx
+
+
+def eval_model(model, params, batch, key, likelihood_fn, shape=None):
   shape = shape if shape else batch.shape
-  def eval_model(made):
-    ms, logp = made(batch)
-    loss = -log_likelihood(ms, logp, batch).mean()
-    u_sample = made.gen(key, shape)
+  def eval_model(model):
+    output = model(batch)
+    loss = -likelihood_fn(*output, batch).mean()
+    u_sample = model.gen(key, shape)
     return loss, u_sample
-  return nn.apply(eval_model, made)({'params': params})
+  return nn.apply(eval_model, model)({'params': params})
 
 
-def train_step(state, batch):
+def train_step(state, batch, likelihood_fn):
   def loss_fn(params):
-    ms, logp = state.apply_fn(
+    output = state.apply_fn(
         {'params': params}, batch,
     )
-    loss = -log_likelihood(ms, logp, batch).mean()
+    loss = -likelihood_fn(*output, batch).mean()
     return loss
   grads = jax.grad(loss_fn)(state.params)
   return state.apply_gradients(grads=grads)
 
 
-def grad_func(state, batch):
+def grad_func(state, batch, likelihood_fn):
   def loss_fn(params):
-    ms, logp = state.apply_fn(
+    output = state.apply_fn(
         {'params': params}, batch,
     )
-    loss = -log_likelihood(ms, logp, batch).mean()
+    loss = -likelihood_fn(*output, batch).mean()
     return loss
   grads = jax.grad(loss_fn)(state.params)
   return grads

--- a/vbjax/train_utils.py
+++ b/vbjax/train_utils.py
@@ -4,40 +4,73 @@ from flax import linen as nn
 
 def log_likelihood_MADE(ms, logp, x, *args):
    u = jnp.exp(.5 * logp) * (x - ms)
-   return -0.5 * (x.shape[1] * jnp.log(2 * jnp.pi) + jnp.sum(u ** 2 - logp, axis=1))
+   return -(- 0.5 * (x.shape[1] * jnp.log(2 * jnp.pi) + jnp.sum(u ** 2 - logp, axis=1)))
 
 
 def log_likelihood_MAF(u, logdet_dudx, *arg):
-    return -0.5 * u.shape[1] * jnp.log(2 * jnp.pi) - 0.5 * jnp.sum(u ** 2, axis=1) + logdet_dudx
+    return -(- 0.5 * u.shape[1] * jnp.log(2 * jnp.pi) - 0.5 * jnp.sum(u ** 2, axis=1) + logdet_dudx)
+
+def mse_ode(traj, x, *arg):
+  return jnp.mean((traj-x)**2)
 
 
-def eval_model(model, params, batch, key, likelihood_fn, shape=None):
+def eval_model_ode(model, params, batch, loss_fn=None, shape=None):
+  batch, i_ext = batch
+  def eval_model(model):
+    output = model(batch, i_ext)
+    loss = loss_fn(output, batch)
+    return loss
+  return nn.apply(eval_model, model)({'params': params})
+
+
+def eval_loss(model, params, batch, loss_fn=None, shape=None):
+  batch, i_ext = batch
+  def eval_model(model):
+    output = model(batch, i_ext)
+    loss = loss_fn(output, batch)
+    return loss
+  return nn.apply(eval_model, model)({'params': params})
+
+def eval_model(model, params, batch, key, loss_fn, shape=None):
   shape = shape if shape else batch.shape
   def eval_model(model):
     output = model(batch)
-    loss = -likelihood_fn(*output, batch).mean()
+    loss = loss_fn(output, batch).mean()
     u_sample = model.gen(key, shape)
     return loss, u_sample
   return nn.apply(eval_model, model)({'params': params})
 
 
-def train_step(state, batch, likelihood_fn):
+def train_step(state, batch, loss_f):
+  batch, p = batch
   def loss_fn(params):
     output = state.apply_fn(
-        {'params': params}, batch,
+        {'params': params}, batch, p,
     )
-    loss = -likelihood_fn(*output, batch).mean()
+    loss = loss_f(output, batch)
     return loss
   grads = jax.grad(loss_fn)(state.params)
   return state.apply_gradients(grads=grads)
 
 
-def grad_func(state, batch, likelihood_fn):
+def grad_func(state, batch, loss_fn):
   def loss_fn(params):
     output = state.apply_fn(
         {'params': params}, batch,
     )
-    loss = -likelihood_fn(*output, batch).mean()
+    loss = loss_fn(output, batch)
     return loss
   grads = jax.grad(loss_fn)(state.params)
   return grads
+
+def loss_t(traj, X):
+    X, iext = X
+    loss_bias  = jnp.var(X, axis=2)*10+1
+    squared_loss_vec = jnp.square(X - traj).mean(axis=(2))
+    return (loss_bias*squared_loss_vec).sum()
+
+def loss_t_unpack(traj, X):
+    X, iext = X
+    loss_bias  = jnp.var(X, axis=2)*40+1
+    squared_loss_vec = jnp.square(X - traj).mean(axis=(2))
+    return (loss_bias*squared_loss_vec).sum(axis=1)

--- a/vbjax/train_utils.py
+++ b/vbjax/train_utils.py
@@ -1,0 +1,39 @@
+import jax
+import jax.numpy as jnp
+from flax import linen as nn
+
+def log_likelihood(ms, logp, x):
+   u = jnp.exp(.5 * logp) * (x - ms)
+   return -0.5 * (x.shape[0] * jnp.log(2 * jnp.pi) + jnp.sum(u ** 2 - logp, axis=1))
+
+
+def eval_MADE(made, params, batch, key, shape=None):
+  shape = shape if shape else batch.shape
+  def eval_model(made):
+    ms, logp = made(batch)
+    loss = -log_likelihood(ms, logp, batch).mean()
+    u_sample = made.gen(key, shape)
+    return loss, u_sample
+  return nn.apply(eval_model, made)({'params': params})
+
+
+def train_step(state, batch):
+  def loss_fn(params):
+    ms, logp = state.apply_fn(
+        {'params': params}, batch,
+    )
+    loss = -log_likelihood(ms, logp, batch).mean()
+    return loss
+  grads = jax.grad(loss_fn)(state.params)
+  return state.apply_gradients(grads=grads)
+
+
+def grad_func(state, batch):
+  def loss_fn(params):
+    ms, logp = state.apply_fn(
+        {'params': params}, batch,
+    )
+    loss = -log_likelihood(ms, logp, batch).mean()
+    return loss
+  grads = jax.grad(loss_fn)(state.params)
+  return grads


### PR DESCRIPTION
I'm currently working on an implementation of MAF in jax/flax
So far I implemented a MADE network.

You can try running train.py

I'll make more modifications soon :
- better configuration of model using ConfigDict
- MAF networks

and probably more...
The goal is to be able to combine MAF and neural ODE

There's still the noise generator hanging there that I refactored.