### PR TITLE
Update integrator documentation and docstrings

### DIFF
--- a/docs/integrators.rst
+++ b/docs/integrators.rst
@@ -120,12 +120,12 @@ make_ode
 
 Create an ordinary differential equation integrator.
 
-.. function:: make_ode(dt, dfun, method='heun', adhoc=None)
+.. function:: make_ode(dt, dfun, adhoc=None, method='heun')
 
    :param float dt: Time step size
    :param callable dfun: Function ``dfun(x, p)`` that returns dx/dt
-   :param str method: Integration method - ``'euler'``, ``'heun'``, or ``'rk4'``
    :param callable adhoc: Optional function ``f(x, p)`` for post-step corrections
+   :param str method: Integration method - ``'euler'``, ``'heun'``, or ``'rk4'``
    :return: Tuple of (step, loop) functions
    :rtype: tuple
 
@@ -241,6 +241,27 @@ Create a stochastic delay differential equation integrator.
    .. note::
       When ``nh=0``, the function automatically uses the optimized SDE integrator
       for better performance and accuracy.
+
+make_continuation
+^^^^^^^^^^^^^^^^^
+
+Helper function to lower memory usage for longer simulations with time delays.
+
+.. function:: make_continuation(run_chunk, chunk_len, max_lag, n_from, n_svar, stochastic=True)
+
+   :param callable run_chunk: The loop function returned by make_dde or make_sdde
+   :param int chunk_len: Number of time steps to compute in one chunk
+   :param int max_lag: Maximum delay in time steps (nh)
+   :param int n_from: Number of nodes/variables
+   :param int n_svar: Number of state variables per node
+   :param bool stochastic: If True, fills the buffer with random noise
+   :return: Function to run the next chunk
+   :rtype: callable
+
+   **WIP**: This API is provisional and may change.
+
+   The continuation function wraps ``run_chunk`` and manages moving the latest states
+   to the first part of the buffer and filling the rest with samples from N(0,1) if required.
 
 Integration Methods
 -------------------

--- a/vbjax/loops.py
+++ b/vbjax/loops.py
@@ -189,6 +189,8 @@ def make_ode(dt, dfun, adhoc=None, method='heun'):
     adhoc : function or None
         Function of the form `f(x, p)` that allows making adhoc corrections
         to states after a step.
+    method : str
+        Integration method, one of 'euler', 'heun', 'rk4'. Default 'heun'.
 
     Returns
     =======
@@ -358,7 +360,7 @@ def make_sdde(dt, nh, dfun, gfun, unroll=1, zero_delays=False, adhoc=None):
 def make_continuation(run_chunk, chunk_len, max_lag, n_from, n_svar, stochastic=True):
     """
     Helper function to lower memory usage for longer simulations with time delays.
-    WIP
+    WIP: This API is provisional and may change.
 
     Takes a function
 
@@ -371,6 +373,26 @@ def make_continuation(run_chunk, chunk_len, max_lag, n_from, n_svar, stochastic=
     The continue_chunk function wraps run_chunk and manages
     moving the latest states to the first part of buf and filling
     the rest with samples from N(0,1) if required.
+
+    Parameters
+    ==========
+    run_chunk : function
+        The loop function returned by make_dde or make_sdde.
+    chunk_len : int
+        Number of time steps to compute in one chunk.
+    max_lag : int
+        Maximum delay in time steps (nh).
+    n_from : int
+        Number of nodes/variables.
+    n_svar : int
+        Number of state variables per node.
+    stochastic : bool
+        If True, fills the buffer with random noise.
+
+    Returns
+    =======
+    continue_chunk : function
+        Function to run the next chunk.
 
     """
     from vbjax import randn


### PR DESCRIPTION
Updated documentation for integrators to correct `make_ode` signature and add missing `make_continuation` documentation. Verified by building docs and running tests.

---
*PR created automatically by Jules for task [15667984374716583177](https://jules.google.com/task/15667984374716583177) started by @maedoc*