### PR TITLE
Improve documentation for integrator functions in loops.py

### DIFF
--- a/docs/integrators.rst
+++ b/docs/integrators.rst
@@ -120,12 +120,12 @@ make_ode
 
 Create an ordinary differential equation integrator.
 
-.. function:: make_ode(dt, dfun, method='heun', adhoc=None)
+.. function:: make_ode(dt, dfun, adhoc=None, method='heun')
 
    :param float dt: Time step size
    :param callable dfun: Function ``dfun(x, p)`` that returns dx/dt
-   :param str method: Integration method - ``'euler'``, ``'heun'``, or ``'rk4'``
    :param callable adhoc: Optional function ``f(x, p)`` for post-step corrections
+   :param str method: Integration method - ``'euler'``, ``'heun'``, or ``'rk4'``
    :return: Tuple of (step, loop) functions
    :rtype: tuple
 

--- a/vbjax/loops.py
+++ b/vbjax/loops.py
@@ -189,6 +189,8 @@ def make_ode(dt, dfun, adhoc=None, method='heun'):
     adhoc : function or None
         Function of the form `f(x, p)` that allows making adhoc corrections
         to states after a step.
+    method : str
+        Integration method. One of 'euler', 'heun', 'rk4'. Default is 'heun'.
 
     Returns
     =======
@@ -232,7 +234,31 @@ def make_ode(dt, dfun, adhoc=None, method='heun'):
 
 
 def make_dde(dt, nh, dfun, unroll=10, adhoc=None):
-    "Invokes make_sdde w/ gfun 0."
+    """Use a Heun scheme to integrate autonomous delay differential
+    equations (DDEs).
+
+    Parameters
+    ==========
+    dt : float
+        Time step
+    nh : int
+        Maximum delay in time steps.
+    dfun : function
+        Function of the form `dfun(xt, x, t, p)` that computes derivatives of
+        the delay differential equation.
+    unroll : int
+        Loop unroll factor for performance. Default is 10.
+    adhoc : function or None
+        Function of the form `f(x,p)` that allows making adhoc corrections after
+        each step.
+
+    Returns
+    =======
+    step : function
+        Function of the form `step((x_t,t), z_t, p)` that takes one step in time.
+    loop : function
+        Function of the form `loop((xs, t), p)` that iteratively calls `step`.
+    """
     return make_sdde(dt, nh, dfun, 0, unroll, adhoc=adhoc)
 
 
@@ -254,6 +280,11 @@ def make_sdde(dt, nh, dfun, gfun, unroll=1, zero_delays=False, adhoc=None):
         of the stochastic differential equation. If a numerical value is
         provided, this is used as a constant diffusion coefficient for additive
         linear SDE.
+    unroll : int
+        Loop unroll factor for performance. Default is 1.
+    zero_delays : bool
+        If True, the history buffer passed to the user functions, on the corrector
+        stage of the Heun method, contains the predictor stage.
     adhoc : function or None
         Function of the form `f(x,p)` that allows making adhoc corrections after
         each step.


### PR DESCRIPTION
This PR improves the documentation for the integrator functions in `vbjax/loops.py`.

Changes:
- Added `method` parameter description to `make_ode` docstring.
- Replaced the one-line docstring of `make_dde` with a complete NumPy-style docstring.
- Added `unroll` and `zero_delays` parameter descriptions to `make_sdde` docstring.
- Corrected the signature of `make_ode` in `docs/integrators.rst` to match the actual function signature (`adhoc` comes before `method`).

These changes ensure that the documentation accurately reflects the code and provides complete information about the available parameters.

---
*PR created automatically by Jules for task [11990387281270280954](https://jules.google.com/task/11990387281270280954) started by @maedoc*